### PR TITLE
fix(security): RLS дыра в crm_manager_queue + race condition в лид-форме

### DIFF
--- a/crm/form.html
+++ b/crm/form.html
@@ -292,7 +292,7 @@ async function submitForm(e) {
 
         // 3. Получаем менеджера через round-robin
         const retreatId = formData.get('retreat_id');
-        const managerId = await getNextManager();
+        const managerId = await getNextManager(retreatId);
 
         const notes = formData.get('notes') || '';
 
@@ -404,26 +404,20 @@ async function updateVaishnava(id, data) {
     }
 }
 
-async function getNextManager() {
-    // Round-robin: берём менеджера с самой старой last_assigned_at
-    const { data: queue } = await db
-        .from('crm_manager_queue')
-        .select('manager_id, last_assigned_at')
-        .eq('is_active', true)
-        .order('last_assigned_at', { ascending: true, nullsFirst: true })
-        .limit(1);
-
-    if (!queue || queue.length === 0) return null;
-
-    const manager = queue[0];
-
-    // Обновляем время последнего назначения
-    await db
-        .from('crm_manager_queue')
-        .update({ last_assigned_at: new Date().toISOString() })
-        .eq('manager_id', manager.manager_id);
-
-    return manager.manager_id;
+async function getNextManager(retreatId) {
+    // Round-robin через SECURITY DEFINER функцию:
+    // - атомарно (FOR UPDATE SKIP LOCKED) — нет race condition между формами
+    // - учитывает retreat_id (очередь менеджеров в БД раздельная для каждого ретрита)
+    // - анон больше не имеет UPDATE на crm_manager_queue — дыра закрыта
+    if (!retreatId) return null;
+    const { data, error } = await db.rpc('assign_next_manager_for_retreat', {
+        p_retreat_id: retreatId
+    });
+    if (error) {
+        console.error('assign_next_manager_for_retreat error:', error);
+        return null;
+    }
+    return data || null;
 }
 
 // ==================== HELPERS ====================


### PR DESCRIPTION
## Summary

Исправлены три бага в round-robin распределении лидов (публичная форма → менеджер):

1. **RLS дыра**: policy `anon_update_crm_manager_queue` использовала `USING (true)` без `WITH CHECK` — анон мог переписать любую колонку, не только `last_assigned_at` (например, `manager_id` или `is_active`).

2. **Race condition**: между `SELECT` очереди и `UPDATE` таймстампа не было блокировки — две одновременные заявки получали одного менеджера.

3. **Фильтр по ретриту**: `getNextManager()` в `crm/form.html` не учитывал `retreat_id`, хотя очередь в БД раздельная для каждого ретрита — лид с ретрита A мог уйти менеджеру ретрита B.

## Что сделано

- Миграция `147_assign_next_manager_function` (уже применена на prod): SECURITY DEFINER функция `assign_next_manager_for_retreat(p_retreat_id)` с `FOR UPDATE SKIP LOCKED`. Policy `anon_update_crm_manager_queue` удалена, `REVOKE UPDATE ... FROM anon`.
- `crm/form.html`: `getNextManager(retreatId)` теперь вызывает RPC.

## Результат

Security advisors: 13 → 12 WARN (закрыт DB-S-03).

## Test plan

- [ ] Публичная лид-форма (`crm/form.html`) отправляет заявку и менеджер корректно назначается
- [ ] Если два человека одновременно заполняют форму на один ретрит — менеджеры разные
- [ ] Лид с ретрита X достаётся только менеджеру, у которого `crm_manager_queue.retreat_id = X`

🤖 Generated with [Claude Code](https://claude.com/claude-code)