### PR TITLE
fix(portal): трансферы сохраняются как datetime-local (DATE-01/02/03)

### DIFF
--- a/guest-portal/index.html
+++ b/guest-portal/index.html
@@ -989,6 +989,6 @@
     <script src="js/portal-layout.js?v=10"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
-    <script src="js/portal-index.js?v=8"></script>
+    <script src="js/portal-index.js?v=9"></script>
 </body>
 </html>

--- a/guest-portal/js/portal-index.js
+++ b/guest-portal/js/portal-index.js
@@ -56,9 +56,10 @@ function toggleTransferEdit(direction) {
     document.getElementById(`${direction}-edit-id`).value = transfer?.id || '';
 
     if (transfer?.flight_datetime) {
-        const dt = new Date(transfer.flight_datetime);
-        const localDt = new Date(dt.getTime() - dt.getTimezoneOffset() * 60000);
-        document.getElementById(`${direction}-edit-datetime`).value = localDt.toISOString().slice(0, 16);
+        // flight_datetime в БД хранится как datetime-local с ложным +00 суффиксом
+        // (см. preliminary.js и CLAUDE.md → правило о датах). Берём первые 16 символов:
+        // "2026-03-20T14:30:00+00" → "2026-03-20T14:30" для <input type="datetime-local">.
+        document.getElementById(`${direction}-edit-datetime`).value = transfer.flight_datetime.slice(0, 16);
     } else {
         document.getElementById(`${direction}-edit-datetime`).value = '';
     }
@@ -87,45 +88,48 @@ async function saveTransferEdit(direction) {
     try {
         let savedTransfer;
 
+        // Передаём datetime-local строку "YYYY-MM-DDTHH:MM" как есть — Postgres
+        // сохранит в TIMESTAMPTZ с суффиксом +00. Тот же формат использует preliminary.js.
+        // Раньше здесь было new Date(datetime).toISOString() — оно сдвигало время
+        // на локальную TZ гостя (в IST на +5:30 часов), что расходилось с преlim-формой.
         if (transferId) {
-            // Обновляем существующую запись
             const { data, error } = await window.portalSupabase
                 .from('guest_transfers')
                 .update({
-                    flight_datetime: datetime ? new Date(datetime).toISOString() : null,
+                    flight_datetime: datetime || null,
                     flight_number: flightNumber || null,
                     needs_transfer: needsTransfer ? 'yes' : 'no'
                 })
                 .eq('id', transferId)
                 .select()
-                .single();
+                .maybeSingle();
 
-            if (error) throw error;
+            if (error || !data) throw error || new Error('Не удалось обновить трансфер (RLS?)');
             savedTransfer = data;
         } else {
-            // Создаём новую запись
             const { data, error } = await window.portalSupabase
                 .from('guest_transfers')
                 .insert({
                     registration_id: currentRegistrationId,
                     direction: direction,
-                    flight_datetime: datetime ? new Date(datetime).toISOString() : null,
+                    flight_datetime: datetime || null,
                     flight_number: flightNumber || null,
                     needs_transfer: needsTransfer ? 'yes' : 'no'
                 })
                 .select()
-                .single();
+                .maybeSingle();
 
-            if (error) throw error;
+            if (error || !data) throw error || new Error('Не удалось создать трансфер (RLS?)');
             savedTransfer = data;
         }
 
         // Обновляем локальные данные
         currentTransfers[direction] = savedTransfer;
 
-        // Обновляем отображение
+        // Обновляем отображение — передаём datetime-local как есть (formatTransferDateTime
+        // делает new Date() что корректно парсит "YYYY-MM-DDTHH:MM" как локальное время).
         if (datetime) {
-            document.getElementById(`${direction}-datetime`).textContent = formatTransferDateTime(new Date(datetime).toISOString());
+            document.getElementById(`${direction}-datetime`).textContent = formatTransferDateTime(datetime);
             document.getElementById(`${direction}-flight`).textContent = flightNumber ? `${PortalLayout.t('portal_flight')} ${flightNumber}` : '—';
             document.getElementById(`${direction}-taxi`).innerHTML = renderTaxiStatus(currentTransfers[direction]);
         } else {


### PR DESCRIPTION
## Summary

Закрывает DATE-01/02/03 из код-ревью в части **новых записей**. Исторические — оставлены с объяснением почему.

## Проблема

\`portal-index.js\` при записи \`flight_datetime\` делал \`new Date(datetime-local).toISOString()\`:
- Гость в IST вводит **19:30** через \`<input type="datetime-local">\`
- \`new Date('2026-03-20T19:30')\` парсится как 19:30 **в локальной TZ браузера** → 14:00 UTC
- В БД сохраняется \`14:00+00\`
- retreat-guests.js (для админа) делает \`.slice(0, 16)\` → показывает \`14:00\`
- Итого: гость ввёл 19:30, админ видит 14:00. Логистика ошибается.

## Что сделано

1. **saveTransferEdit**: передаём datetime-local строку \`"YYYY-MM-DDTHH:MM"\` напрямую в Supabase. Postgres сохраняет с суффиксом \`+00\`, но часы/минуты = как ввёл гость. Совпадает с форматом preliminary.js / person.js.
2. **toggleTransferEdit**: читаем через \`.slice(0, 16)\` вместо сложного \`getTimezoneOffset\`-хака (тот работал, но был хрупким).
3. Бонусом заменил \`.single()\` → \`.maybeSingle()\` (паттерн из PR #9).
4. Бампнул \`portal-index.js\` v8 → v9.

## Исторические данные

**НЕ мигрирую** 119 записей с UTC-форматом. Причина: без \`created_by\` невозможно отличить портальные записи (нужно +5:30) от преlim-записей (где \`00\` минута — реальное время рейса). Слепая миграция испортила бы часть.

**Обходной путь**: админы могут поправить странные времена через retreat-guests.html; при следующем редактировании через портал запись перезапишется правильно.

**На будущее**: стоит добавить колонку \`created_via\` (\`'portal'\` / \`'admin'\` / \`'import'\`) чтобы такие миграции были возможны.

## Test plan

- [ ] Гость из портала: открыть трансфер, ввести время 19:30, сохранить. Проверить что в БД \`flight_datetime\` → \`2026-XX-XX 19:30:00+00\` (а не \`14:00+00\`)
- [ ] Админ через retreat-guests.html: видит тот же 19:30
- [ ] Открыть старую запись через портал → отображается как есть (возможно сдвинутое время — это legacy); пересохранить → становится корректным

🤖 Generated with [Claude Code](https://claude.com/claude-code)