### PR TITLE
fix(db): assign_next_manager_for_retreat — правильная колонка retreat_id

### DIFF
--- a/supabase/migrations/151_fix_assign_next_manager.sql
+++ b/supabase/migrations/151_fix_assign_next_manager.sql
@@ -1,0 +1,54 @@
+-- HOTFIX для миграции 147: функция assign_next_manager_for_retreat
+-- использовала несуществующую колонку retreat_id в crm_manager_queue.
+-- При вызове возвращала 400 "column retreat_id does not exist" —
+-- лид-форма (crm/form.html) не могла назначить менеджера.
+--
+-- Правильная архитектура:
+--   crm_manager_queue (manager_id, last_assigned_at, is_active)
+--     — ГЛОБАЛЬНАЯ очередь round-robin (без retreat_id).
+--   crm_retreat_managers (retreat_id, manager_id, is_active)
+--     — связь «какие менеджеры работают с каким ретритом».
+--
+-- Новая логика:
+--   1. Берём менеджеров, закреплённых за данным ретритом
+--      (JOIN crm_retreat_managers.retreat_id = p_retreat_id).
+--   2. Среди них выбираем того, у кого самая старая last_assigned_at
+--      в глобальной очереди.
+--   3. Обновляем его last_assigned_at.
+--   4. FOR UPDATE OF q SKIP LOCKED — атомарная блокировка,
+--      предотвращает race condition между одновременными лид-формами.
+--
+-- Применено на prod 2026-04-17.
+
+CREATE OR REPLACE FUNCTION public.assign_next_manager_for_retreat(p_retreat_id uuid)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_manager_id uuid;
+BEGIN
+  SELECT q.manager_id
+    INTO v_manager_id
+  FROM public.crm_manager_queue q
+  JOIN public.crm_retreat_managers rm
+    ON rm.manager_id = q.manager_id
+  WHERE q.is_active = true
+    AND rm.is_active = true
+    AND rm.retreat_id = p_retreat_id
+  ORDER BY q.last_assigned_at ASC NULLS FIRST
+  LIMIT 1
+  FOR UPDATE OF q SKIP LOCKED;
+
+  IF v_manager_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  UPDATE public.crm_manager_queue
+     SET last_assigned_at = now()
+   WHERE manager_id = v_manager_id;
+
+  RETURN v_manager_id;
+END;
+$$;


### PR DESCRIPTION
## Summary

**Хотфикс регрессии из PR #10.** При smoke-тесте обнаружил что функция \`assign_next_manager_for_retreat\` из миграции 147 использовала несуществующую колонку \`retreat_id\` в \`crm_manager_queue\`.

### Воспроизведение бага

\`\`\`
curl -X POST https://mymrijdfqeevoaocbzfy.supabase.co/rest/v1/rpc/assign_next_manager_for_retreat \\
  -H "apikey: ANON" -H "Authorization: Bearer ANON" \\
  -H "Content-Type: application/json" \\
  -d '{"p_retreat_id": "8837f0e0-a428-4ae2-bb12-a870b3a5a6d7"}'

→ 400 {"code":"42703","message":"column \\"retreat_id\\" does not exist"}
\`\`\`

То есть публичная лид-форма при попытке назначить менеджера получала 400 → менеджер не назначался в deal.

### Правильная архитектура

- \`crm_manager_queue (manager_id, last_assigned_at, is_active)\` — ГЛОБАЛЬНАЯ очередь round-robin (без retreat_id).
- \`crm_retreat_managers (retreat_id, manager_id, is_active)\` — связь «какие менеджеры работают с каким ретритом».

Мой код в миграции 147 спутал эти таблицы.

### Исправление (миграция 151, уже применена на prod)

\`\`\`sql
SELECT q.manager_id FROM crm_manager_queue q
JOIN crm_retreat_managers rm ON rm.manager_id = q.manager_id
WHERE q.is_active AND rm.is_active AND rm.retreat_id = p_retreat_id
ORDER BY q.last_assigned_at ASC NULLS FIRST LIMIT 1
FOR UPDATE OF q SKIP LOCKED;
\`\`\`

### Verification

Проверил 3 последовательными вызовами на реальном ретрите (Сева-ретрит, 2 менеджера):
\`\`\`
call 1: "7146d14e..."
call 2: "c13424af..."
call 3: "7146d14e..."
\`\`\`
Round-robin работает.

### Как я это нашёл

Тестировал anon-запросы к prod через curl после всех миграций. Отдельный урок: при создании SECURITY DEFINER функций в будущем — прогонять реальные HTTP-вызовы с anon-ключом, не полагаться только на \`SELECT\` из psql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)