### PR TITLE
hotfix: прод сломан — debug() в config.js до загрузки utils.js

### DIFF
--- a/admin-create-accounts.html
+++ b/admin-create-accounts.html
@@ -55,7 +55,7 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=3"></script>
+    <script src="js/config.js?v=4"></script>
     <script>
         // ВАЖНО: Для создания пользователей нужен Service Role Key!
         // Получите его в Supabase Dashboard → Settings → API → service_role (secret)

--- a/ashram/dashboard-vaishnavas.html
+++ b/ashram/dashboard-vaishnavas.html
@@ -223,7 +223,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/ashram/festivals.html
+++ b/ashram/festivals.html
@@ -167,7 +167,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/ashram/retreat-schedule.html
+++ b/ashram/retreat-schedule.html
@@ -151,7 +151,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/ashram/retreats.html
+++ b/ashram/retreats.html
@@ -333,7 +333,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/crm/activity-log.html
+++ b/crm/activity-log.html
@@ -116,7 +116,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/currencies.html
+++ b/crm/currencies.html
@@ -106,7 +106,7 @@
     <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/dashboard.html
+++ b/crm/dashboard.html
@@ -489,7 +489,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/deal.html
+++ b/crm/deal.html
@@ -513,7 +513,7 @@
 </dialog>
 
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/deals.html
+++ b/crm/deals.html
@@ -239,7 +239,7 @@
     <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/form.html
+++ b/crm/form.html
@@ -113,7 +113,7 @@
     </div>
 </div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script>
 // ==================== I18N ====================
 const LANG = new URLSearchParams(window.location.search).get('lang') === 'en' ? 'en' : 'ru';

--- a/crm/index.html
+++ b/crm/index.html
@@ -132,7 +132,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/managers.html
+++ b/crm/managers.html
@@ -73,7 +73,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/services.html
+++ b/crm/services.html
@@ -140,7 +140,7 @@
     <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/tags.html
+++ b/crm/tags.html
@@ -88,7 +88,7 @@
     <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/tasks.html
+++ b/crm/tasks.html
@@ -142,7 +142,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/templates.html
+++ b/crm/templates.html
@@ -100,7 +100,7 @@
     <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>

--- a/crm/utm-links.html
+++ b/crm/utm-links.html
@@ -102,7 +102,7 @@
 
 <div id="footer-placeholder"></div>
 
-<script src="../js/config.js?v=3"></script>
+<script src="../js/config.js?v=4"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
 <script src="../js/layout.js?v=10"></script>

--- a/guest-portal/auth-callback/index.html
+++ b/guest-portal/auth-callback/index.html
@@ -77,7 +77,7 @@
     </div>
 
     <!-- Scripts -->
-    <script src="../js/portal-config.js?v=2"></script>
+    <script src="../js/portal-config.js?v=3"></script>
     <script src="../js/portal-auth.js"></script>
     <script>
         const db = window.portalSupabase;

--- a/guest-portal/contacts.html
+++ b/guest-portal/contacts.html
@@ -188,7 +188,7 @@
     <div id="footer-placeholder"></div>
 
     <!-- Scripts -->
-    <script src="js/portal-config.js?v=2"></script>
+    <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
     <script src="js/portal-layout.js?v=10"></script>
 

--- a/guest-portal/index.html
+++ b/guest-portal/index.html
@@ -984,7 +984,7 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="js/portal-config.js?v=2"></script>
+    <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
     <script src="js/portal-layout.js?v=10"></script>
     <script src="../js/date-utils.js?v=3"></script>

--- a/guest-portal/js/portal-config.js
+++ b/guest-portal/js/portal-config.js
@@ -59,8 +59,9 @@ window.PORTAL_CONFIG = {
     TELEGRAM_BOT_NAME: 'rupaseva_bot'
 };
 
-// Лог для отладки
-debug('[ENV]', window.PORTAL_CONFIG.ENV + ':', location.hostname || 'file://', '→', window.PORTAL_CONFIG.SUPABASE_URL);
+// NB: debug() определён в utils.js, но portal-config грузится отдельным стеком.
+// [ENV] лог всегда виден — намеренно, помогает диагностировать окружение.
+console.log('[ENV]', window.PORTAL_CONFIG.ENV + ':', location.hostname || 'file://', '→', window.PORTAL_CONFIG.SUPABASE_URL);
 
 // Создаём ЕДИНСТВЕННЫЙ экземпляр Supabase клиента
 if (typeof window.supabase !== 'undefined') {

--- a/guest-portal/login/index.html
+++ b/guest-portal/login/index.html
@@ -196,7 +196,7 @@
     </div>
 
     <!-- Scripts -->
-    <script src="../js/portal-config.js?v=2"></script>
+    <script src="../js/portal-config.js?v=3"></script>
     <script src="../js/portal-auth.js"></script>
     <script>
         const db = window.portalSupabase;

--- a/guest-portal/materials-admin.html
+++ b/guest-portal/materials-admin.html
@@ -248,7 +248,7 @@
     </div>
 
     <!-- Scripts -->
-    <script src="js/portal-config.js?v=2"></script>
+    <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
     <script src="js/portal-layout.js?v=10"></script>
     <script src="../js/date-utils.js?v=3"></script>

--- a/guest-portal/materials.html
+++ b/guest-portal/materials.html
@@ -192,7 +192,7 @@
     </footer>
 
     <!-- Scripts -->
-    <script src="js/portal-config.js?v=2"></script>
+    <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>

--- a/guest-portal/photos.html
+++ b/guest-portal/photos.html
@@ -310,7 +310,7 @@
 
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script src="js/portal-config.js?v=2"></script>
+    <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
 
     <script>

--- a/guest-portal/reset-password/index.html
+++ b/guest-portal/reset-password/index.html
@@ -121,7 +121,7 @@
     </div>
 
     <!-- Scripts -->
-    <script src="../js/portal-config.js?v=2"></script>
+    <script src="../js/portal-config.js?v=3"></script>
     <script>
         const db = window.portalSupabase;
         const currentLang = localStorage.getItem('srsk_lang') || 'ru';

--- a/guest-portal/retreats.html
+++ b/guest-portal/retreats.html
@@ -99,7 +99,7 @@
     <div id="footer-placeholder"></div>
 
     <!-- Scripts -->
-    <script src="js/portal-config.js?v=2"></script>
+    <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
     <script src="js/portal-layout.js?v=10"></script>
     <script src="../js/date-utils.js?v=3"></script>

--- a/guest-signup.html
+++ b/guest-signup.html
@@ -86,7 +86,7 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=3"></script>
+    <script src="js/config.js?v=4"></script>
     <script>
         const db = window.supabaseClient;
 

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
         </div>
     </main>
 
-    <script src="js/config.js?v=3"></script>
+    <script src="js/config.js?v=4"></script>
     <script src="js/auth-check.js?v=6"></script>
     <script src="js/cache.js?v=1"></script>
     <script src="js/utils.js?v=4"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -49,7 +49,10 @@ window.CONFIG = {
     SUPABASE_SERVICE_ROLE_KEY: null // TODO: Вставить service role key если нужен
 };
 
-debug('[ENV]', window.CONFIG.ENV + ':', location.hostname || 'file://', '→', window.CONFIG.SUPABASE_URL);
+// NB: debug() определён в utils.js, который грузится ПОСЛЕ config.js.
+// На этом этапе его ещё нет — используем console.log напрямую.
+// [ENV] лог всегда виден в консоли — намеренно, помогает диагностировать окружение.
+console.log('[ENV]', window.CONFIG.ENV + ':', location.hostname || 'file://', '→', window.CONFIG.SUPABASE_URL);
 
 
 // Создаём ЕДИНСТВЕННЫЙ экземпляр Supabase клиента

--- a/kitchen/dictionaries.html
+++ b/kitchen/dictionaries.html
@@ -89,7 +89,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/menu-board.html
+++ b/kitchen/menu-board.html
@@ -387,7 +387,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/menu-templates.html
+++ b/kitchen/menu-templates.html
@@ -285,7 +285,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/menu.html
+++ b/kitchen/menu.html
@@ -472,7 +472,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/products.html
+++ b/kitchen/products.html
@@ -220,7 +220,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/recipe-edit.html
+++ b/kitchen/recipe-edit.html
@@ -373,7 +373,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/recipe.html
+++ b/kitchen/recipe.html
@@ -256,7 +256,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/kitchen/recipes.html
+++ b/kitchen/recipes.html
@@ -99,7 +99,7 @@
     <!-- Футер (вставляется из layout.js) -->
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/pending-approval.html
+++ b/pending-approval.html
@@ -47,7 +47,7 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=3"></script>
+    <script src="js/config.js?v=4"></script>
     <script>
         const db = window.supabaseClient;
 

--- a/photos/manage.html
+++ b/photos/manage.html
@@ -340,7 +340,7 @@
     </div>
 
     <!-- Core Dependencies -->
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/photos/search.html
+++ b/photos/search.html
@@ -195,7 +195,7 @@
     </div>
 
     <!-- Core Dependencies -->
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/photos/upload.html
+++ b/photos/upload.html
@@ -308,7 +308,7 @@
     <div id="footer-placeholder"></div>
 
     <!-- Core Dependencies -->
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/placement/arrivals.html
+++ b/placement/arrivals.html
@@ -181,7 +181,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/placement/bookings.html
+++ b/placement/bookings.html
@@ -370,7 +370,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/placement/departures.html
+++ b/placement/departures.html
@@ -168,7 +168,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/placement/timeline.html
+++ b/placement/timeline.html
@@ -962,7 +962,7 @@
         </form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/placement/transfers.html
+++ b/placement/transfers.html
@@ -181,7 +181,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/buildings.html
+++ b/reception/buildings.html
@@ -151,7 +151,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/reception/cleaning.html
+++ b/reception/cleaning.html
@@ -469,7 +469,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/dictionaries.html
+++ b/reception/dictionaries.html
@@ -77,7 +77,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/floor-plan-editor.html
+++ b/reception/floor-plan-editor.html
@@ -214,7 +214,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/floor-plan.html
+++ b/reception/floor-plan.html
@@ -272,7 +272,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/prasad.html
+++ b/reception/prasad.html
@@ -192,7 +192,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/residents-list.html
+++ b/reception/residents-list.html
@@ -139,7 +139,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/reception/rooms.html
+++ b/reception/rooms.html
@@ -215,7 +215,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/retreat.html
+++ b/retreat.html
@@ -578,7 +578,7 @@
 
     <!-- Scripts -->
     <script src="js/date-utils.js?v=3"></script>
-    <script src="guest-portal/js/portal-config.js?v=2"></script>
+    <script src="guest-portal/js/portal-config.js?v=3"></script>
     <script>
         const db = window.portalSupabase;
         let currentLang = localStorage.getItem('srsk_lang') || 'ru';

--- a/settings/translations.html
+++ b/settings/translations.html
@@ -185,7 +185,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/settings/user-management.html
+++ b/settings/user-management.html
@@ -181,7 +181,7 @@
         </div>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/settings/users.html
+++ b/settings/users.html
@@ -65,7 +65,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/stock/inventory.html
+++ b/stock/inventory.html
@@ -187,7 +187,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/stock/issue.html
+++ b/stock/issue.html
@@ -407,7 +407,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/stock/receive.html
+++ b/stock/receive.html
@@ -391,7 +391,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/stock/requests.html
+++ b/stock/requests.html
@@ -372,7 +372,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/stock/stock-settings.html
+++ b/stock/stock-settings.html
@@ -223,7 +223,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/stock/stock.html
+++ b/stock/stock.html
@@ -78,7 +78,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/team-signup.html
+++ b/team-signup.html
@@ -86,7 +86,7 @@
         </div>
     </div>
 
-    <script src="js/config.js?v=3"></script>
+    <script src="js/config.js?v=4"></script>
     <script>
         const db = window.supabaseClient;
 

--- a/vaishnavas/groups.html
+++ b/vaishnavas/groups.html
@@ -117,7 +117,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/vaishnavas/guests.html
+++ b/vaishnavas/guests.html
@@ -197,7 +197,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/vaishnavas/index.html
+++ b/vaishnavas/index.html
@@ -224,7 +224,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>

--- a/vaishnavas/person.html
+++ b/vaishnavas/person.html
@@ -1012,7 +1012,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/vaishnavas/preliminary.html
+++ b/vaishnavas/preliminary.html
@@ -960,7 +960,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/vaishnavas/retreat-guests.html
+++ b/vaishnavas/retreat-guests.html
@@ -428,7 +428,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/vaishnavas/retreat-prasad.html
+++ b/vaishnavas/retreat-prasad.html
@@ -111,7 +111,7 @@
 
     <div id="footer-placeholder"></div>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>

--- a/vaishnavas/team.html
+++ b/vaishnavas/team.html
@@ -204,7 +204,7 @@
         <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
-    <script src="../js/config.js?v=3"></script>
+    <script src="../js/config.js?v=4"></script>
     <script src="../js/auth-check.js?v=6"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>


### PR DESCRIPTION
## ⚠️ КРИТИЧНАЯ РЕГРЕССИЯ от PR #13

Sed-замена \`console.log → debug()\` в chore/hygiene затронула \`config.js\` и \`portal-config.js\`, которые **загружаются ДО utils.js** (где определён \`debug\`).

### Симптом

В prod при каждой новой загрузке страницы:
\`\`\`
Uncaught ReferenceError: debug is not defined
  at config.js:52:1
\`\`\`

**Последствия:**
- \`window.supabaseClient\` не создаётся → ни один запрос к БД не работает
- Пользователи с кэшированным старым JS (до v=3) продолжают работать, но у любого свежего визита — белая страница
- В логах api это выглядит как падение количества запросов от определённых User-Agent'ов

### Как нашёл

Smoke-тест через sandbox-инициализацию цепочки скриптов в правильном порядке:
\`\`\`js
new Function(config.js + cache.js + utils.js)
// → ReferenceError: debug is not defined
\`\`\`

### Fix

\`config.js:52\` и \`portal-config.js:63\`:
\`\`\`diff
- debug('[ENV]', ...);
+ // NB: debug() определён в utils.js, грузится ПОСЛЕ config.js.
+ // [ENV] лог всегда виден — намеренно для диагностики окружения.
+ console.log('[ENV]', ...);
\`\`\`

Bump: config.js v3 → v4, portal-config.js v2 → v3.

### Test plan

- [x] Sandbox-инициализация всей цепочки → все объекты создаются
- [ ] После мерджа: открыть in.rupaseva.com в инкогнито → не должно быть ошибок в консоли
- [ ] Проверить логи Supabase API — трафик должен вернуться

### Уроки

1. Всегда после sed-замен прогонять sandbox-инициализацию цепочки скриптов
2. Никогда не использовать в \`config.js\` ничего что определено позже в цепочке загрузки

🤖 Generated with [Claude Code](https://claude.com/claude-code)