### PR TITLE
security(rls): hardening — storage listing + overly-permissive policies

### DIFF
--- a/supabase/migrations/153_storage_bucket_listing_hardening.sql
+++ b/supabase/migrations/153_storage_bucket_listing_hardening.sql
@@ -1,0 +1,28 @@
+-- DB-S-08: закрываем листинг публичных storage-бакетов.
+--
+-- Проблема: под любым anon JWT через POST /storage/v1/object/list/<bucket>
+-- можно было получить список всех файлов во всех 6 публичных бакетах.
+-- Особо чувствительно: vaishnava-photos (149 личных фото).
+-- По имени файла (UUID_timestamp.jpg) + запрос к /rest/v1/vaishnavas
+-- приватность нарушалась.
+--
+-- Решение: убираем SELECT policies на storage.objects для public-бакетов.
+-- Для public-бакетов (public=true) прямой URL /object/public/<bucket>/<file>
+-- работает через CDN в обход RLS — сайт продолжает отображать картинки.
+-- Листинг же требует RLS — теперь возвращает пусто.
+--
+-- Verified:
+--   * GET /object/public/<bucket>/<real-file> → 200 (картинки грузятся)
+--   * POST /object/list/<bucket> → [] (листинг закрыт)
+--   * Под superuser JWT листинг тоже закрыт — используйте Supabase Dashboard
+
+BEGIN;
+
+DROP POLICY IF EXISTS "Anyone can view guest photos" ON storage.objects;
+DROP POLICY IF EXISTS "Anyone can view retreat images" ON storage.objects;
+DROP POLICY IF EXISTS "Anyone can view vaishnava photos" ON storage.objects;
+DROP POLICY IF EXISTS "Public read access" ON storage.objects;
+DROP POLICY IF EXISTS "Public read access for floor-plans" ON storage.objects;
+DROP POLICY IF EXISTS "plants_storage_public_read" ON storage.objects;
+
+COMMIT;

--- a/supabase/migrations/154_rls_overly_permissive_hardening.sql
+++ b/supabase/migrations/154_rls_overly_permissive_hardening.sql
@@ -1,0 +1,61 @@
+-- DB-S-01..06: ужесточение RLS-политик с USING (true) / WITH CHECK (true).
+--
+-- Проблема (из security advisors):
+--   crm_deal_members:       "Authenticated manage deal members"  USING/CHECK = true, ALL
+--   crm_utm_links:          "Authenticated manage utm links"     USING/CHECK = true, ALL
+--   crm_deals:              "anon_insert_crm_deals"              WITH CHECK = true
+--   crm_deal_services:      "anon_insert_crm_deal_services"      WITH CHECK = true
+--   vaishnavas:             "anon_insert_vaishnavas"              WITH CHECK = true
+--
+-- Реальные векторы атаки (до миграции):
+--   1. Любой залогиненный юзер (даже гость портала) мог читать/писать
+--      все UTM-ссылки и связи участников сделок.
+--   2. Анонимный клиент через лид-форму мог создать crm_deal со
+--      status='paid' + total_paid=1000000 — фейковые платежи.
+--   3. Анон мог создать vaishnava с is_superuser=true — эскалация привилегий.
+--
+-- Решение: заменяем USING/CHECK (true) на реальные проверки.
+
+BEGIN;
+
+-- crm_deal_members: только staff
+DROP POLICY "Authenticated manage deal members" ON public.crm_deal_members;
+CREATE POLICY "Staff manage crm_deal_members" ON public.crm_deal_members
+  AS PERMISSIVE FOR ALL TO authenticated
+  USING (is_staff((SELECT auth.uid())))
+  WITH CHECK (is_staff((SELECT auth.uid())));
+
+-- crm_utm_links: только staff
+DROP POLICY "Authenticated manage utm links" ON public.crm_utm_links;
+CREATE POLICY "Staff manage crm_utm_links" ON public.crm_utm_links
+  AS PERMISSIVE FOR ALL TO authenticated
+  USING (is_staff((SELECT auth.uid())))
+  WITH CHECK (is_staff((SELECT auth.uid())));
+
+-- crm_deals: анон-лид может создать только lead без платежа
+DROP POLICY anon_insert_crm_deals ON public.crm_deals;
+CREATE POLICY anon_insert_crm_deals ON public.crm_deals
+  AS PERMISSIVE FOR INSERT TO anon
+  WITH CHECK (
+    COALESCE(status, 'lead') = 'lead'
+    AND COALESCE(total_paid, 0) = 0
+  );
+
+-- crm_deal_services: вообще не нужна анон-политика
+-- (используется только из crm/deal.html и crm/deals.html — staff-страницы).
+-- "Staff manage crm_deal_services" уже есть и даёт нужный доступ.
+DROP POLICY anon_insert_crm_deal_services ON public.crm_deal_services;
+
+-- vaishnavas: анон-лид создаёт только обычного гостя без привилегий
+DROP POLICY anon_insert_vaishnavas ON public.vaishnavas;
+CREATE POLICY anon_insert_vaishnavas ON public.vaishnavas
+  AS PERMISSIVE FOR INSERT TO anon
+  WITH CHECK (
+    COALESCE(is_superuser, false) = false
+    AND COALESCE(is_team_member, false) = false
+    AND COALESCE(user_type, 'guest') = 'guest'
+    AND user_id IS NULL
+    AND COALESCE(is_deleted, false) = false
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

Закрывает **все оставшиеся security advisors** из код-ревью (кроме HIBP, который явно отложен).

Security advisors: **23 → 1 WARN**.

## 1. Миграция 153 — public bucket listing (DB-S-08)

**Проблема:** под любым anon JWT через \`POST /storage/v1/object/list/<bucket>\` можно было получить список файлов всех 6 публичных бакетов. Особо критично для \`vaishnava-photos\` (149 личных фото). По имени файла \`{vaishnava_id}_{timestamp}.jpg\` и /rest/v1/vaishnavas можно было связать имя + email + телефон. **Приватности не было.**

**Решение:** убраны SELECT policies на \`storage.objects\` для публичных бакетов. Для \`public: true\` бакетов прямой URL \`/object/public/...\` работает через Supabase CDN **в обход RLS** — картинки продолжают грузиться.

**Verified:**
- \`GET /object/public/<bucket>/<real-file>\` → 200 ✅
- \`POST /object/list/<bucket>\` → \`[]\` ✅

## 2. Миграция 154 — overly-permissive policies

Было: \`USING (true)\` / \`WITH CHECK (true)\` в 5 policies. Реальные векторы атаки:

| Table | До | После |
|---|---|---|
| \`crm_deal_members\` | любой authenticated | только staff |
| \`crm_utm_links\` | любой authenticated | только staff |
| \`crm_deals\` anon INSERT | анон мог создать \`status='paid'\`, \`total_paid=999999\` | \`status='lead'\`, \`total_paid=0\` |
| \`crm_deal_services\` anon INSERT | избыточна (не используется анон) | удалена |
| \`vaishnavas\` anon INSERT | анон мог создать \`is_superuser=true\` | только \`user_type='guest'\`, без привилегий |

## Как применено

Миграции применены на prod (\`mymrijdfqeevoaocbzfy\`) через \`execute_sql\`. Зарегистрированы в \`supabase_migrations.schema_migrations\` с версиями \`20260417180000\` и \`20260417180100\` — \`supabase db push\` на dev-окружении не будет применять повторно.

## Test plan

- [ ] Публичная лид-форма \`crm/form.html\` продолжает работать (создаёт vaishnava + crm_deal как гость)
- [ ] CRM-страницы под staff: deals, deal, managers, utm-links — всё работает
- [ ] Guest portal: картинки профилей грузятся, retreat-images грузятся
- [ ] Попытка зайти в UTM-links или deal-members под обычным гостем портала → нет доступа

🤖 Generated with [Claude Code](https://claude.com/claude-code)