### PR TITLE
chore(rls): удалены избыточные дубликаты policies

### DIFF
--- a/supabase/migrations/155_remove_duplicate_policies.sql
+++ b/supabase/migrations/155_remove_duplicate_policies.sql
@@ -1,0 +1,39 @@
+-- Удаление избыточных/небезопасных дубликатов RLS-policies.
+-- Обнаружено при аудите под admin JWT: несколько пар policies,
+-- которые делают одно и то же, при этом одна из них шире другой.
+--
+-- Применено на prod 2026-04-17.
+--
+-- Performance advisors: -2 multiple_permissive_policies warnings.
+-- Security: retreats anon теперь видит только is_public=true (было — всё).
+--
+-- ⚠️ ВАЖНО: оставшиеся архитектурные проблемы (для отдельной сессии):
+--
+-- 1. vaishnavas: "Users can view vaishnavas based on permissions" для
+--    roles=public с условием (is_deleted=false) даёт анону PII всех гостей
+--    (имя, email, phone, telegram). Причина: crm/form.html →
+--    findOrCreateVaishnava ищет по phone/email. Правильный фикс —
+--    перевести на SECURITY DEFINER функцию find_or_create_vaishnava(...).
+--
+-- 2. crm_deals "anon_read_crm_deals" (true) — анон видит все сделки.
+--    Причина: crm/form.html проверяет дубль (vaishnava_id, retreat_id).
+--    Правильный фикс — SECURITY DEFINER функция check_duplicate_deal(...).
+--
+-- 3. face_tags, photo_faces, holidays и др. с qual="true" для anon —
+--    разной степени приватности. Нужен отдельный audit.
+
+BEGIN;
+
+-- crm_deals: полный дубликат — оба с одинаковой логикой "vaishnava_id связан с user_id"
+-- Оставляем guest_read_own_crm_deals (уже с (SELECT auth.uid()) после миграции 150).
+DROP POLICY "Guest read own crm_deals" ON public.crm_deals;
+
+-- retreats: избыточная anon_read_retreats (true) перекрывает "Public read retreats".
+-- После удаления anon видит только ретриты с is_public=true (черновики скрыты).
+DROP POLICY anon_read_retreats ON public.retreats;
+
+-- vaishnavas: anon_select_vaishnavas (is_deleted=false) — дубликат условия
+-- из "Users can view vaishnavas based on permissions" (см. архитектурный долг выше).
+DROP POLICY anon_select_vaishnavas ON public.vaishnavas;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Миграция 155 (применена на prod) — чистка 3 дубликатов RLS policies, обнаруженных при аудите под admin JWT.

| Table | Удалено | Остаётся | Почему OK |
|---|---|---|---|
| \`crm_deals\` | \"Guest read own crm_deals\" | \`guest_read_own_crm_deals\` | Идентичная логика, но вторая уже с \`(SELECT auth.uid())\` после миграции 150 |
| \`retreats\` | \`anon_read_retreats\` (USING true) | \"Public read retreats\" (is_public=true) | Улучшение: непубличные черновики скрыты от анона |
| \`vaishnavas\` | \`anon_select_vaishnavas\` (is_deleted=false) | "Users can view vaishnavas based on permissions\" (public) | Дубликат — условие уже содержится в основной policy |

## Закрывает

- DB-P-10 (дубликат crm_deals policies)
- DB-P-11 (дубликат retreats policies)
- Частично DB-P-9 (vaishnavas multi-permissive)

## ⚠️ Архитектурный долг (для отдельной сессии)

Обнаружено при аудите, но НЕ фиксится в этом PR:

1. **vaishnavas**: "Users can view vaishnavas based on permissions" с условием (is_deleted=false) даёт анону PII всех гостей. Причина: crm/form.html → findOrCreateVaishnava ищет по phone/email. Правильный фикс — SECURITY DEFINER функция find_or_create_vaishnava(phone, email, ...).

2. **crm_deals**: anon_read_crm_deals (true) — анон видит все сделки. Причина: crm/form.html проверяет дубль (vaishnava_id, retreat_id). Правильный фикс — SECURITY DEFINER check_duplicate_deal(vaishnava_id, retreat_id).

3. **face_tags, photo_faces, holidays, plant_users и др.** с qual=\"true\" для anon/public — нужен отдельный audit.

## Test plan

- [ ] Публичная страница ретрита \`retreat.html?slug=...\` грузится (для is_public=true)
- [ ] Непубличный черновик ретрита (is_public=false) — анон больше НЕ видит в списке
- [ ] Лид-форма \`crm/form.html\` продолжает работать (остаётся anon_read_crm_deals)
- [ ] Guest portal гостя: видит свои сделки

🤖 Generated with [Claude Code](https://claude.com/claude-code)