### PR TITLE
hotfix: лид-форма падала на INSERT с email — RLS блокировала

### DIFF
--- a/supabase/migrations/156_fix_anon_insert_vaishnavas.sql
+++ b/supabase/migrations/156_fix_anon_insert_vaishnavas.sql
@@ -1,0 +1,32 @@
+-- HOTFIX для миграции 154.
+--
+-- Проблема обнаружена smoke-тестом под anon:
+-- INSERT vaishnavas с полем email падал с
+-- "new row violates row-level security policy for table vaishnavas".
+--
+-- Причина: триггер auto_create_auth_for_vaishnava (SECURITY DEFINER)
+-- при email IS NOT NULL:
+--   1. Создаёт запись в auth.users
+--   2. Устанавливает NEW.user_id := v_auth_id
+-- Это происходит ПЕРЕД WITH CHECK проверкой RLS. Моя проверка
+-- user_id IS NULL → false → RLS блокирует.
+--
+-- Fix: убираем проверку user_id IS NULL. Защита от эскалации
+-- привилегий остаётся через остальные условия (is_superuser=false,
+-- is_team_member=false, user_type='guest').
+--
+-- Применено на prod 2026-04-17.
+
+BEGIN;
+
+DROP POLICY anon_insert_vaishnavas ON public.vaishnavas;
+CREATE POLICY anon_insert_vaishnavas ON public.vaishnavas
+  AS PERMISSIVE FOR INSERT TO anon
+  WITH CHECK (
+    COALESCE(is_superuser, false) = false
+    AND COALESCE(is_team_member, false) = false
+    AND COALESCE(user_type, 'guest') = 'guest'
+    AND COALESCE(is_deleted, false) = false
+  );
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ Критичная регрессия от PR #17 / миграции 154

Обнаружено smoke-тестом под anon. Публичная лид-форма \`crm/form.html\` при email НЕ NULL падала:

\`\`\`
POST /rest/v1/vaishnavas
→ 401 {"code":"42501","message":"new row violates row-level security policy for table vaishnavas"}
\`\`\`

### Причина

Триггер \`auto_create_auth_for_vaishnava\` (SECURITY DEFINER, BEFORE INSERT) при \`email IS NOT NULL\`:
1. Создаёт запись в \`auth.users\`
2. Устанавливает \`NEW.user_id := v_auth_id\`

Это происходит **до** проверки \`WITH CHECK\`. Моё условие \`user_id IS NULL\` → false → RLS блокирует.

### Fix (миграция 156)

Убираю \`user_id IS NULL\` из WITH CHECK. Остальные защиты работают:
- \`is_superuser = false\`
- \`is_team_member = false\`
- \`user_type = 'guest'\`

### Verification (end-to-end)

- ✅ INSERT vaishnavas с email → 200, триггер создал auth.users
- ✅ INSERT crm_deals status=lead → 200
- ✅ RPC assign_next_manager_for_retreat → UUID
- ✅ Атака is_superuser=true → блокируется (401)

Применено на prod.

### Урок дня

Любые \`WITH CHECK\` на таблицах с **SECURITY DEFINER BEFORE триггерами** надо тестировать end-to-end под реальной anon-ролью. Я сразу начал с WRITE-теста этой миграции, но неправильно интерпретировал результат (думал "форма сломается" — но не убедился).

🤖 Generated with [Claude Code](https://claude.com/claude-code)