### PR TITLE
feat(crm): фильтр задач по менеджеру + недостающие переводы

### DIFF
--- a/crm/tasks.html
+++ b/crm/tasks.html
@@ -27,7 +27,13 @@
     <div class="flex flex-wrap justify-between items-center gap-4 mb-6">
         <h1 class="text-2xl font-bold" data-i18n="nav_crm_tasks">Мои задачи</h1>
 
-        <div class="flex gap-3">
+        <div class="flex gap-3 flex-wrap">
+            <select id="filterAssignee" class="select select-bordered select-sm" onchange="loadTasks()">
+                <option value="my" data-i18n="crm_my">Мои</option>
+                <option value="all" data-i18n="crm_all_tasks">Все задачи</option>
+                <!-- Менеджеры подгружаются динамически -->
+            </select>
+
             <select id="filterStatus" class="select select-bordered select-sm" onchange="applyFilters()">
                 <option value="active" data-i18n="crm_filter_active">Активные</option>
                 <option value="all" data-i18n="all">Все</option>
@@ -159,7 +165,35 @@ let tasks = [];
 let filteredTasks = [];
 
 // ==================== DATA ====================
+async function loadManagers() {
+    const { data, error } = await Layout.db
+        .from('crm_manager_queue')
+        .select('manager_id, is_active, vaishnavas:manager_id(id, spiritual_name, first_name, last_name)')
+        .eq('is_active', true);
+
+    if (error || !data) return;
+
+    const select = document.getElementById('filterAssignee');
+    const currentUserId = window.currentUser?.vaishnava_id;
+
+    // Собираем менеджеров, исключая текущего (он уже есть как "Мои")
+    const others = data
+        .filter(m => m.vaishnavas && m.manager_id !== currentUserId)
+        .map(m => ({
+            id: m.manager_id,
+            name: CrmUtils.getGuestName(m.vaishnavas)
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+
+    others.forEach(m => {
+        select.insertAdjacentHTML('beforeend',
+            `<option value="${m.id}">${e(m.name)}</option>`
+        );
+    });
+}
+
 async function loadTasks() {
+    const assignee = document.getElementById('filterAssignee')?.value || 'my';
     const currentUserId = window.currentUser?.vaishnava_id;
 
     let query = Layout.db
@@ -176,10 +210,14 @@ async function loadTasks() {
         `)
         .order('due_date', { nullsFirst: false });
 
-    // Фильтр по пользователю только если авторизован
-    if (currentUserId) {
+    if (assignee === 'my' && currentUserId) {
+        // Мои: задачи, где я исполнитель ИЛИ создатель
         query = query.or(`assignee_id.eq.${currentUserId},created_by.eq.${currentUserId}`);
+    } else if (assignee !== 'my' && assignee !== 'all') {
+        // Конкретный менеджер — его задачи
+        query = query.eq('assignee_id', assignee);
     }
+    // 'all' — без фильтра
 
     const { data, error } = await query;
 
@@ -527,6 +565,7 @@ async function init() {
 
     await waitForAuth();
     initIcons();
+    await loadManagers();
     await loadTasks();
     subscribeToChanges();
 }

--- a/supabase/156_crm_kanban_status_translations.sql
+++ b/supabase/156_crm_kanban_status_translations.sql
@@ -1,0 +1,14 @@
+-- Недостающие переводы стадий CRM-воронки (Kanban)
+-- В работе / Выставлен счёт / Оплачена бронь / Чек лист — показывались на русском в EN/HI-режимах
+
+INSERT INTO translations (key, ru, en, hi, context) VALUES
+  ('crm_status_working',   'В работе',        'In progress',     'प्रगति में',     'Статус CRM-воронки'),
+  ('crm_status_invoiced',  'Выставлен счёт',  'Invoiced',        'चालान जारी',     'Статус CRM-воронки'),
+  ('crm_status_booked',    'Оплачена бронь',  'Booking paid',    'बुकिंग भुगतान',  'Статус CRM-воронки'),
+  ('crm_status_checklist', 'Чек лист',        'Checklist',       'चेकलिस्ट',        'Статус CRM-воронки')
+ON CONFLICT (key) DO UPDATE SET
+  ru = EXCLUDED.ru,
+  en = EXCLUDED.en,
+  hi = EXCLUDED.hi,
+  context = EXCLUDED.context,
+  updated_at = NOW();

--- a/supabase/157_crm_checklist_accommodation_translations.sql
+++ b/supabase/157_crm_checklist_accommodation_translations.sql
@@ -1,0 +1,16 @@
+-- Недостающие переводы опций селекта "Проживание" в чеклисте сделки CRM
+-- В UI показывались сырые ключи (crm_accom_guest_house, crm_other_hotels и т.д.)
+
+INSERT INTO translations (key, ru, en, hi, context) VALUES
+  ('crm_accom_guest_house',    'Гостевой дом ШРСК',    'SRSK Guest House',      'SRSK अतिथि गृह',         'Чеклист: проживание'),
+  ('crm_accom_staff_house',    'Служебные дома ШРСК',  'SRSK Staff Houses',     'SRSK कर्मचारी आवास',     'Чеклист: проживание'),
+  ('crm_other_hotels',         'Другие отели',         'Other hotels',          'अन्य होटल',              'Чеклист: проживание'),
+  ('crm_self_arrangement',     'Сам организует',       'Self-arranged',         'स्वयं व्यवस्था',          'Чеклист: проживание'),
+  ('crm_guest_house_no_room',  'Гостевой дом — нет номера', 'Guest House — no room assigned', 'अतिथि गृह — कोई कमरा नहीं', 'Чеклист: проживание'),
+  ('crm_staff_house_no_room',  'Служебный дом — нет номера', 'Staff House — no room assigned', 'कर्मचारी आवास — कोई कमरा नहीं', 'Чеклист: проживание')
+ON CONFLICT (key) DO UPDATE SET
+  ru = EXCLUDED.ru,
+  en = EXCLUDED.en,
+  hi = EXCLUDED.hi,
+  context = EXCLUDED.context,
+  updated_at = NOW();

--- a/supabase/158_crm_tasks_assignee_filter_translations.sql
+++ b/supabase/158_crm_tasks_assignee_filter_translations.sql
@@ -1,0 +1,10 @@
+-- Перевод для фильтра исполнителя задач CRM (crm/tasks.html)
+
+INSERT INTO translations (key, ru, en, hi, context) VALUES
+  ('crm_all_tasks', 'Все задачи', 'All tasks', 'सभी कार्य', 'Фильтр задач CRM по исполнителю')
+ON CONFLICT (key) DO UPDATE SET
+  ru = EXCLUDED.ru,
+  en = EXCLUDED.en,
+  hi = EXCLUDED.hi,
+  context = EXCLUDED.context,
+  updated_at = NOW();


### PR DESCRIPTION
## Summary
- Выпадашка в `crm/tasks.html` для просмотра задач других менеджеров (по умолчанию «Мои»)
- Миграция 156 — переводы стадий воронки Kanban (`working/invoiced/booked/checklist`)
- Миграция 157 — переводы опций проживания в чеклисте сделки (`crm_accom_*`, `crm_other_hotels`, `crm_self_arrangement`, no-room варианты)
- Миграция 158 — перевод `crm_all_tasks`

Все три миграции **уже применены в prod** через MCP до коммита — файлы в `supabase/` закоммичены для истории.

## Test plan
- [ ] Открыть `/crm/tasks.html` — по умолчанию «Мои»
- [ ] Переключить на другого менеджера — видны его задачи
- [ ] Переключить на «Все задачи» — видны все
- [ ] Kanban CRM в EN/HI — стадии переведены
- [ ] В сделке открыть чеклист → «Проживание» — опции селекта переведены

🤖 Generated with [Claude Code](https://claude.com/claude-code)