### PR TITLE
chore: bump layout.js v11 + перевод nav_crm_utm_links

### DIFF
--- a/ashram/dashboard-vaishnavas.html
+++ b/ashram/dashboard-vaishnavas.html
@@ -227,7 +227,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/eating-utils.js?v=3"></script>
 

--- a/ashram/festivals.html
+++ b/ashram/festivals.html
@@ -174,7 +174,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let holidays = [];

--- a/ashram/retreat-schedule.html
+++ b/ashram/retreat-schedule.html
@@ -157,7 +157,7 @@
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let retreat = null;

--- a/ashram/retreats.html
+++ b/ashram/retreats.html
@@ -341,7 +341,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let retreats = [];

--- a/crm/activity-log.html
+++ b/crm/activity-log.html
@@ -120,7 +120,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/currencies.html
+++ b/crm/currencies.html
@@ -110,7 +110,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/dashboard.html
+++ b/crm/dashboard.html
@@ -493,7 +493,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/deal.html
+++ b/crm/deal.html
@@ -517,7 +517,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/deals.html
+++ b/crm/deals.html
@@ -243,7 +243,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/index.html
+++ b/crm/index.html
@@ -149,7 +149,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/managers.html
+++ b/crm/managers.html
@@ -78,7 +78,7 @@
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
 <script src="../js/date-utils.js?v=3"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 
 <script>

--- a/crm/services.html
+++ b/crm/services.html
@@ -144,7 +144,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/tags.html
+++ b/crm/tags.html
@@ -92,7 +92,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/task-templates.html
+++ b/crm/task-templates.html
@@ -119,7 +119,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/tasks.html
+++ b/crm/tasks.html
@@ -152,7 +152,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 <script src="../js/date-utils.js?v=3"></script>
 

--- a/crm/templates.html
+++ b/crm/templates.html
@@ -104,7 +104,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/utm-links.html
+++ b/crm/utm-links.html
@@ -105,7 +105,7 @@
 <script src="../js/config.js?v=4"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=10"></script>
+<script src="../js/layout.js?v=11"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/auth-check.js?v=6"></script>
 

--- a/guest-portal/contacts.html
+++ b/guest-portal/contacts.html
@@ -190,7 +190,7 @@
     <!-- Scripts -->
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=10"></script>
+    <script src="js/portal-layout.js?v=11"></script>
 
     <script>
         async function init() {

--- a/guest-portal/index.html
+++ b/guest-portal/index.html
@@ -986,7 +986,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=10"></script>
+    <script src="js/portal-layout.js?v=11"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
     <script src="js/portal-index.js?v=10"></script>

--- a/guest-portal/materials-admin.html
+++ b/guest-portal/materials-admin.html
@@ -250,7 +250,7 @@
     <!-- Scripts -->
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=10"></script>
+    <script src="js/portal-layout.js?v=11"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
 

--- a/guest-portal/retreats.html
+++ b/guest-portal/retreats.html
@@ -101,7 +101,7 @@
     <!-- Scripts -->
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=10"></script>
+    <script src="js/portal-layout.js?v=11"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
 

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
     <script src="js/utils.js?v=4"></script>
     <script src="js/translit.js"></script>
     <script src="js/auto-translate.js"></script>
-    <script src="js/layout.js?v=10"></script>
+    <script src="js/layout.js?v=11"></script>
     <script>
         window.onLanguageChange = function(lang) {
             Layout.updateAllTranslations();

--- a/kitchen/dictionaries.html
+++ b/kitchen/dictionaries.html
@@ -95,7 +95,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let currentTab = 'recipe_categories';

--- a/kitchen/menu-board.html
+++ b/kitchen/menu-board.html
@@ -394,7 +394,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script src="../js/pages/kitchen-menu-board.js?v=3"></script>
 </body>

--- a/kitchen/menu-templates.html
+++ b/kitchen/menu-templates.html
@@ -292,7 +292,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let templates = [];

--- a/kitchen/menu.html
+++ b/kitchen/menu.html
@@ -479,7 +479,7 @@
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script src="../js/pages/kitchen-menu.js?v=20"></script>
 </body>

--- a/kitchen/products.html
+++ b/kitchen/products.html
@@ -226,7 +226,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let currentCategory = 'all';

--- a/kitchen/recipe-edit.html
+++ b/kitchen/recipe-edit.html
@@ -379,7 +379,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let recipeId = null;

--- a/kitchen/recipe.html
+++ b/kitchen/recipe.html
@@ -262,7 +262,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let recipe = null;

--- a/kitchen/recipes.html
+++ b/kitchen/recipes.html
@@ -105,7 +105,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         const PAGE_SIZE = 50;

--- a/photos/manage.html
+++ b/photos/manage.html
@@ -345,7 +345,7 @@
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
 
     <!-- Page Logic -->
     <script src="../photos/js/manage.js"></script>

--- a/photos/search.html
+++ b/photos/search.html
@@ -200,7 +200,7 @@
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
 
     <!-- Page Logic -->
     <script src="../photos/js/search.js"></script>

--- a/photos/upload.html
+++ b/photos/upload.html
@@ -313,7 +313,7 @@
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
 
     <!-- Upload Logic -->
     <script src="../photos/js/upload.js"></script>

--- a/placement/arrivals.html
+++ b/placement/arrivals.html
@@ -188,7 +188,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         const t = key => Layout.t(key);
 

--- a/placement/bookings.html
+++ b/placement/bookings.html
@@ -378,7 +378,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/pages/bookings.js"></script>
 </body>
 </html>

--- a/placement/departures.html
+++ b/placement/departures.html
@@ -175,7 +175,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/pages/departures.js"></script>
 
 </body>

--- a/placement/timeline.html
+++ b/placement/timeline.html
@@ -969,7 +969,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
     function toggleFullscreen(btn) {
         const isFS = document.body.classList.toggle('board-fullscreen');

--- a/placement/transfers.html
+++ b/placement/transfers.html
@@ -187,7 +187,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         let transfers = [];
         let residentsMap = new Map();

--- a/reception/buildings.html
+++ b/reception/buildings.html
@@ -159,7 +159,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let buildings = [];

--- a/reception/cleaning.html
+++ b/reception/cleaning.html
@@ -476,7 +476,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let cleaningData = []; // { date, rooms: [...] } - upcoming

--- a/reception/dictionaries.html
+++ b/reception/dictionaries.html
@@ -83,7 +83,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let currentTab = 'building_types';

--- a/reception/floor-plan-editor.html
+++ b/reception/floor-plan-editor.html
@@ -220,7 +220,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let building = null;

--- a/reception/floor-plan.html
+++ b/reception/floor-plan.html
@@ -279,7 +279,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let buildings = [];

--- a/reception/prasad.html
+++ b/reception/prasad.html
@@ -199,7 +199,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script>
         // ==================== STATE ====================

--- a/reception/residents-list.html
+++ b/reception/residents-list.html
@@ -146,7 +146,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let residents = [];

--- a/reception/rooms.html
+++ b/reception/rooms.html
@@ -223,7 +223,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let rooms = [];

--- a/settings/translations.html
+++ b/settings/translations.html
@@ -191,7 +191,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         const PAGE_SIZE = 50;

--- a/settings/user-management.html
+++ b/settings/user-management.html
@@ -187,7 +187,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         const db = window.supabaseClient;
 

--- a/settings/users.html
+++ b/settings/users.html
@@ -71,7 +71,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let users = [];

--- a/stock/inventory.html
+++ b/stock/inventory.html
@@ -194,7 +194,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let inventories = [];

--- a/stock/issue.html
+++ b/stock/issue.html
@@ -415,7 +415,7 @@
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/eating-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let issuances = [];

--- a/stock/receive.html
+++ b/stock/receive.html
@@ -399,7 +399,7 @@
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/eating-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let receipts = [];

--- a/stock/requests.html
+++ b/stock/requests.html
@@ -379,7 +379,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script src="../js/pages/stock-requests.js?v=8"></script>
 

--- a/stock/stock-settings.html
+++ b/stock/stock-settings.html
@@ -229,7 +229,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let buyers = [];

--- a/stock/stock.html
+++ b/stock/stock.html
@@ -84,7 +84,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
         // ==================== STATE ====================
         let currentCategory = 'all';

--- a/supabase/161_crm_utm_links_translation.sql
+++ b/supabase/161_crm_utm_links_translation.sql
@@ -1,0 +1,7 @@
+-- Недостающий перевод для пункта меню «UTM-метки»
+
+INSERT INTO translations (key, ru, en, hi, context) VALUES
+  ('nav_crm_utm_links', 'UTM-метки', 'UTM links', 'UTM लिंक', 'Навигация CRM')
+ON CONFLICT (key) DO UPDATE SET
+  ru = EXCLUDED.ru, en = EXCLUDED.en, hi = EXCLUDED.hi,
+  context = EXCLUDED.context, updated_at = NOW();

--- a/vaishnavas/groups.html
+++ b/vaishnavas/groups.html
@@ -123,7 +123,7 @@
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/pages/groups.js"></script>
 
 </body>

--- a/vaishnavas/guests.html
+++ b/vaishnavas/guests.html
@@ -203,7 +203,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/vaishnavas-utils.js?v=2"></script>
     <script>
         const V = VaishnavasUtils;

--- a/vaishnavas/index.html
+++ b/vaishnavas/index.html
@@ -232,7 +232,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/vaishnavas-utils.js?v=2"></script>
     <script>
         const V = VaishnavasUtils;

--- a/vaishnavas/person.html
+++ b/vaishnavas/person.html
@@ -1020,7 +1020,7 @@
     <script src="../js/auto-translate.js"></script>
     <script src="../js/modal-utils.js?v=3"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/pages/person.js?v=11"></script>
 </body>
 </html>

--- a/vaishnavas/preliminary.html
+++ b/vaishnavas/preliminary.html
@@ -967,7 +967,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script>
     function toggleFullscreen(btn) {
         const isFS = document.body.classList.toggle('board-fullscreen');

--- a/vaishnavas/retreat-guests.html
+++ b/vaishnavas/retreat-guests.html
@@ -434,7 +434,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/modal-utils.js?v=3"></script>
     <script src="../js/pages/retreat-guests.js?v=2"></script>
 </body>

--- a/vaishnavas/retreat-prasad.html
+++ b/vaishnavas/retreat-prasad.html
@@ -117,7 +117,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/pages/retreat-prasad.js?v=2"></script>
 </body>

--- a/vaishnavas/team.html
+++ b/vaishnavas/team.html
@@ -211,7 +211,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=10"></script>
+    <script src="../js/layout.js?v=11"></script>
     <script src="../js/vaishnavas-utils.js?v=2"></script>
     <script>
         const V = VaishnavasUtils;


### PR DESCRIPTION
## Summary
- Бамп `layout.js?v=10 → v=11` во всех 63 HTML для подхвата нового пункта меню «Шаблоны автозадач» (меню кэшировано на уровне браузера)
- Добавлен недостающий перевод `nav_crm_utm_links` — показывался как сырой ключ `NAV_CRM_UTM_LINKS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)