### PR TITLE
fix(crm): конверсия на дашборде + фильтр менеджеров в сделках

### DIFF
--- a/crm/dashboard.html
+++ b/crm/dashboard.html
@@ -353,24 +353,6 @@
                 </div>
             </div>
 
-            <!-- Источники трафика -->
-            <div class="collapsible-card" style="background: #FEF3C7;">
-                <div class="collapsible-header" data-section="sources" onclick="toggleSection('sources')">
-                    <div class="section-icon" style="background: #F59E0B;">
-                        <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0118 16.5h-2.25m-7.5 0h7.5m-7.5 0l-1 3m8.5-3l1 3m0 0l.5 1.5m-.5-1.5h-9.5m0 0l-.5 1.5" />
-                        </svg>
-                    </div>
-                    <span class="section-title flex-1" style="color: #92400E;">Источники трафика</span>
-                    <svg class="w-5 h-5 chevron" style="color: #92400E;" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                    </svg>
-                </div>
-                <div id="trafficSources" class="collapsible-body space-y-2" data-section="sources">
-                    <div class="text-center py-4"><span class="loading loading-spinner loading-md"></span></div>
-                </div>
-            </div>
-
             <!-- Нагрузка менеджеров - Фиолетовый фон -->
             <div class="collapsible-card" style="background: #EDE9FE;">
                 <div class="collapsible-header" data-section="managers" onclick="toggleSection('managers')">
@@ -430,7 +412,7 @@
 
             <!-- Источники заявок - Голубой фон -->
             <div class="collapsible-card" style="background: #CFFAFE;">
-                <div class="collapsible-header" data-section="sources" onclick="toggleSection('sources')">
+                <div class="collapsible-header" data-section="lead_sources" onclick="toggleSection('lead_sources')">
                     <div class="section-icon" style="background: #0891B2;">
                         <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
@@ -441,7 +423,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
                 </div>
-                <div id="sourcesChart" class="collapsible-body space-y-2" data-section="sources">
+                <div id="sourcesChart" class="collapsible-body space-y-2" data-section="lead_sources">
                     <div class="text-center py-4"><span class="loading loading-spinner loading-md"></span></div>
                 </div>
             </div>
@@ -645,8 +627,9 @@ async function loadCancellationReasons() {
 function renderMetrics() {
     const total = deals.length;
     const active = deals.filter(d => CrmUtils.isActive(d)).length;
-    const completed = deals.filter(d => d.status === 'completed').length;
-    const conversion = total > 0 ? Math.round(completed / total * 100) : 0;
+    const PAID_STATUSES = ['booked', 'checklist', 'ready', 'completed'];
+    const paid = deals.filter(d => PAID_STATUSES.includes(d.status)).length;
+    const conversion = total > 0 ? Math.round(paid / total * 100) : 0;
     // Используем total_paid из сделок для консистентности с блоком "Финансы"
     const revenue = deals.reduce((sum, d) => sum + Number(d.total_paid || 0), 0);
 
@@ -895,7 +878,7 @@ function renderCancellations() {
 }
 
 function renderSources() {
-    const container = document.getElementById('trafficSources') || document.getElementById('sourcesChart');
+    const container = document.getElementById('sourcesChart');
 
     const bySource = {};
     deals.forEach(deal => {

--- a/crm/deals.html
+++ b/crm/deals.html
@@ -367,6 +367,27 @@ async function loadDeals() {
     applyFilters();
 }
 
+async function loadManagers() {
+    const { data, error } = await Layout.db
+        .from('crm_manager_queue')
+        .select('manager_id, is_active, vaishnavas:manager_id(id, spiritual_name, first_name, last_name)')
+        .eq('is_active', true);
+
+    if (error || !data) return;
+
+    const select = document.getElementById('filterManager');
+    const managers = data
+        .filter(m => m.vaishnavas)
+        .map(m => ({ id: m.manager_id, name: CrmUtils.getGuestName(m.vaishnavas) }))
+        .sort((a, b) => a.name.localeCompare(b.name, 'ru'));
+
+    managers.forEach(m => {
+        select.insertAdjacentHTML('beforeend',
+            `<option value="${m.id}">${e(m.name)}</option>`
+        );
+    });
+}
+
 async function loadGuests() {
     const { data } = await Layout.db
         .from('vaishnavas')
@@ -471,6 +492,7 @@ function applyFilters() {
         // Менеджер
         if (manager === 'my' && d.manager_id !== currentUserId) return false;
         if (manager === 'unassigned' && d.manager_id) return false;
+        if (manager && manager !== 'my' && manager !== 'unassigned' && d.manager_id !== manager) return false;
 
         // Поиск
         if (search) {
@@ -880,6 +902,7 @@ async function init() {
     });
 
     await loadData();
+    await loadManagers();
     populateBulkSelects();
 }
 


### PR DESCRIPTION
## Summary
- **dashboard.html**: конверсия считается по оплаченным (`booked` + `checklist` + `ready` + `completed`), а не только по `completed` — раньше показывало 0%, пока никто не дошёл до финальной стадии.
- **dashboard.html**: убран дубликат «Источники трафика» (левая колонка), «Источники заявок» (правая колонка) получил уникальный `data-section="lead_sources"` и теперь не висит со спиннером.
- **deals.html**: в фильтр «Менеджер» добавлены все активные менеджеры из `crm_manager_queue` (как в канбане [crm/index.html](crm/index.html)); `applyFilters()` фильтрует по конкретному ID.

## Test plan
- [ ] Открыть `/crm/dashboard.html` — проверить, что «Конверсия» не 0%
- [ ] На дашборде блок «Источники заявок» рендерится (не висит)
- [ ] Collapse «Источников заявок» не синхронизируется с другими секциями
- [ ] Открыть `/crm/deals.html` — в фильтре «Менеджер» видны реальные имена после «Все/Мои/Не назначен»
- [ ] Выбор конкретного менеджера фильтрует таблицу

🤖 Generated with [Claude Code](https://claude.com/claude-code)