### PR TITLE
feat(crm): вкладка «Предоплата» (PR 2/2)

### DIFF
--- a/ashram/dashboard-vaishnavas.html
+++ b/ashram/dashboard-vaishnavas.html
@@ -227,7 +227,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/eating-utils.js?v=3"></script>
 

--- a/ashram/festivals.html
+++ b/ashram/festivals.html
@@ -174,7 +174,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let holidays = [];

--- a/ashram/retreat-schedule.html
+++ b/ashram/retreat-schedule.html
@@ -157,7 +157,7 @@
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let retreat = null;

--- a/ashram/retreats.html
+++ b/ashram/retreats.html
@@ -341,7 +341,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let retreats = [];

--- a/crm/activity-log.html
+++ b/crm/activity-log.html
@@ -120,7 +120,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/currencies.html
+++ b/crm/currencies.html
@@ -110,7 +110,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/dashboard.html
+++ b/crm/dashboard.html
@@ -475,7 +475,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/deal.html
+++ b/crm/deal.html
@@ -383,8 +383,26 @@
             <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost">✕</button></form>
         </div>
         <div id="paymentDetailsContent" class="space-y-3"></div>
-        <div class="modal-action mt-4">
+        <div class="modal-action mt-4 flex-wrap">
+            <button class="btn btn-sm btn-ghost" id="paymentDetailsHistoryBtn" data-i18n="crm_payment_history">История изменений</button>
             <button class="btn btn-sm btn-error btn-outline" id="paymentDetailsDeleteBtn" data-i18n="crm_delete_payment">Удалить платёж</button>
+            <form method="dialog"><button class="btn btn-sm" data-i18n="close">Закрыть</button></form>
+        </div>
+    </div>
+    <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<!-- Модалка истории изменений платежа -->
+<dialog id="paymentHistoryModal" class="modal">
+    <div class="modal-box max-w-md">
+        <div class="flex justify-between items-start mb-4">
+            <h3 class="font-bold text-lg" data-i18n="crm_payment_history">История изменений</h3>
+            <form method="dialog"><button class="btn btn-sm btn-circle btn-ghost">✕</button></form>
+        </div>
+        <div id="paymentHistoryContent" class="space-y-2 max-h-96 overflow-y-auto">
+            <div class="text-center py-4"><span class="loading loading-spinner loading-sm"></span></div>
+        </div>
+        <div class="modal-action mt-4">
             <form method="dialog"><button class="btn btn-sm" data-i18n="close">Закрыть</button></form>
         </div>
     </div>
@@ -513,7 +531,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 
@@ -1683,7 +1701,76 @@ function showPaymentDetails(id) {
         deletePayment(id);
     };
 
+    const historyBtn = document.getElementById('paymentDetailsHistoryBtn');
+    historyBtn.onclick = () => {
+        document.getElementById('paymentDetailsModal').close();
+        openPaymentHistoryModal(id);
+    };
+
     document.getElementById('paymentDetailsModal').showModal();
+}
+
+async function openPaymentHistoryModal(paymentId) {
+    const modal = document.getElementById('paymentHistoryModal');
+    const content = document.getElementById('paymentHistoryContent');
+    content.innerHTML = '<div class="text-center py-4"><span class="loading loading-spinner loading-sm"></span></div>';
+    modal.showModal();
+
+    const { data, error } = await Layout.db
+        .from('crm_payment_history')
+        .select('*, changed_by:changed_by(spiritual_name, first_name, last_name)')
+        .eq('payment_id', paymentId)
+        .order('changed_at', { ascending: false });
+
+    if (error) { Layout.handleError(error, t('crm_payment_history')); return; }
+
+    const events = data || [];
+    if (events.length === 0) {
+        content.innerHTML = '<p class="text-base-content/50 text-center py-4">Нет записей</p>';
+        return;
+    }
+
+    const systemById = {};
+    payments.forEach(p => { if (p.payment_system) systemById[p.payment_system.id] = p.payment_system; });
+
+    content.innerHTML = events.map(ev => {
+        const when = new Date(ev.changed_at).toLocaleString('ru-RU', {
+            day: '2-digit', month: '2-digit', year: 'numeric',
+            hour: '2-digit', minute: '2-digit'
+        });
+        const who = ev.changed_by ? e(CrmUtils.getGuestShortName(ev.changed_by)) : '<span class="text-base-content/40">система</span>';
+        const action = formatHistoryAction(ev, systemById);
+        return `
+            <div class="border-l-2 border-base-300 pl-3 py-1">
+                <div class="text-xs text-base-content/50">${e(when)} — ${who}</div>
+                <div class="text-sm">${action}</div>
+            </div>
+        `;
+    }).join('');
+}
+
+function formatHistoryAction(ev, systemById) {
+    if (ev.action === 'created') {
+        return `Создан платёж <span class="font-mono">${e(ev.new_value || '')}</span>`;
+    }
+    if (ev.action === 'confirmed') return '<span class="text-emerald-600 font-medium">✓ Платёж подтверждён</span>';
+    if (ev.action === 'unconfirmed') return '<span class="text-amber-600 font-medium">○ Подтверждение отменено</span>';
+    if (ev.action === 'updated') {
+        if (ev.field === 'payment_system_id') {
+            const oldName = ev.old_value && systemById[ev.old_value] ? Layout.getName(systemById[ev.old_value]) : (ev.old_value || '—');
+            const newName = ev.new_value && systemById[ev.new_value] ? Layout.getName(systemById[ev.new_value]) : (ev.new_value || '—');
+            return `Платёжная система: <span class="line-through text-base-content/40">${e(oldName)}</span> → <span class="font-medium">${e(newName)}</span>`;
+        }
+        if (ev.field === 'amount') {
+            return `Сумма: <span class="line-through text-base-content/40">${e(ev.old_value || '')}</span> → <span class="font-mono font-medium">${e(ev.new_value || '')}</span>`;
+        }
+        if (ev.field === 'received_at') {
+            const fmt = v => v ? new Date(v).toLocaleDateString('ru-RU') : '—';
+            return `Дата платежа: <span class="line-through text-base-content/40">${e(fmt(ev.old_value))}</span> → <span class="font-medium">${e(fmt(ev.new_value))}</span>`;
+        }
+        return `${e(ev.field || 'поле')}: ${e(ev.old_value || '—')} → ${e(ev.new_value || '—')}`;
+    }
+    return e(ev.action);
 }
 
 function updatePaymentRate() {

--- a/crm/deals.html
+++ b/crm/deals.html
@@ -243,7 +243,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/index.html
+++ b/crm/index.html
@@ -149,7 +149,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/managers.html
+++ b/crm/managers.html
@@ -78,7 +78,7 @@
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
 <script src="../js/date-utils.js?v=3"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 
 <script>

--- a/crm/prepayments.html
+++ b/crm/prepayments.html
@@ -1,0 +1,609 @@
+<!DOCTYPE html>
+<html lang="ru" data-theme="light">
+<head>
+    <script src="../js/color-init.js?v=1"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title data-i18n-title="crm_prepayments_page_title">Предоплата — CRM — ШРСК</title>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@4.12.14/dist/full.min.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script>tailwind.config = { theme: { extend: { screens: { 'desktop': '1200px' } } } }</script>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/common.css">
+    <style>
+        .prepayment-row td { vertical-align: middle; }
+        .status-chip {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 2px 10px; border-radius: 999px;
+            font-size: 12px; font-weight: 600; white-space: nowrap;
+            cursor: default;
+        }
+        .status-chip.clickable { cursor: pointer; }
+        .status-chip.clickable:hover { filter: brightness(1.05); }
+        .status-chip.confirmed { background: #dcfce7; color: #166534; }
+        .status-chip.not-confirmed { background: #fef3c7; color: #92400e; }
+        .status-dot { width: 8px; height: 8px; border-radius: 50%; }
+        .status-dot.confirmed { background: #22c55e; }
+        .status-dot.not-confirmed { background: #f59e0b; }
+        .inline-edit-cell { cursor: pointer; border-radius: 6px; padding: 4px 6px; }
+        .inline-edit-cell:hover { background: oklch(var(--b2)); }
+        .inline-edit-cell.readonly { cursor: default; }
+        .inline-edit-cell.readonly:hover { background: transparent; }
+        .flash-saved { animation: flash-saved 0.8s ease; }
+        @keyframes flash-saved {
+            0% { background: transparent; }
+            30% { background: #dcfce7; }
+            100% { background: transparent; }
+        }
+    </style>
+</head>
+<body class="bg-base-200 min-h-screen flex flex-col">
+
+<div id="header-placeholder"></div>
+
+<main class="container mx-auto px-4 py-6 flex-1">
+    <div class="flex flex-wrap justify-between items-center gap-4 mb-6">
+        <h1 class="text-2xl font-bold" data-i18n="nav_crm_prepayments">Предоплата</h1>
+    </div>
+
+    <!-- Фильтры -->
+    <div class="card bg-base-100 shadow-sm mb-4">
+        <div class="card-body p-4">
+            <div class="flex flex-wrap gap-3 items-end">
+                <div class="form-control">
+                    <label class="label py-1"><span class="label-text text-xs" data-i18n="crm_retreat">Ретрит</span></label>
+                    <select id="filterRetreat" class="select select-bordered select-sm" onchange="applyFilters()">
+                        <option value="" data-i18n="all">Все</option>
+                    </select>
+                </div>
+
+                <div class="form-control">
+                    <label class="label py-1"><span class="label-text text-xs" data-i18n="crm_prepayment_confirmation_status">Статус подтверждения</span></label>
+                    <select id="filterStatus" class="select select-bordered select-sm" onchange="applyFilters()">
+                        <option value="" data-i18n="crm_all_statuses">Все статусы</option>
+                        <option value="confirmed" data-i18n="crm_prepayment_confirmed">Подтверждена</option>
+                        <option value="not_confirmed" data-i18n="crm_prepayment_not_confirmed">Не подтверждена</option>
+                    </select>
+                </div>
+
+                <div class="form-control">
+                    <label class="label py-1"><span class="label-text text-xs" data-i18n="crm_payment_system">Платёжная система</span></label>
+                    <select id="filterSystem" class="select select-bordered select-sm" onchange="applyFilters()">
+                        <option value="" data-i18n="crm_all_systems">Все системы</option>
+                    </select>
+                </div>
+
+                <div class="form-control flex-1 min-w-[200px]">
+                    <label class="label py-1"><span class="label-text text-xs" data-i18n="search">Поиск</span></label>
+                    <input type="text" id="filterSearch" class="input input-bordered input-sm"
+                           placeholder="Имя, телефон..." oninput="applyFiltersDebounced()">
+                </div>
+
+                <button class="btn btn-ghost btn-sm" onclick="resetFilters()" data-i18n="reset">Сбросить</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="flex items-center justify-between mb-4">
+        <div class="text-sm text-base-content/70">
+            <span id="statsTotal">—</span>
+            <span id="statsUnconfirmed" class="ml-4 text-amber-600 hidden"></span>
+        </div>
+        <button class="btn btn-sm btn-outline gap-1" onclick="exportXlsx()">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" /></svg>
+            <span data-i18n="crm_download_xlsx">Скачать .xlsx</span>
+        </button>
+    </div>
+
+    <!-- Таблица -->
+    <div class="card bg-base-100 shadow-sm">
+        <div class="card-body p-0">
+            <div class="overflow-x-auto">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th class="cursor-pointer hover:bg-base-200" onclick="setSort('guest')">
+                                <span class="inline-flex items-center gap-1" data-i18n="crm_guest">Гость <span id="sort-guest" class="text-xs opacity-50"></span></span>
+                            </th>
+                            <th class="cursor-pointer hover:bg-base-200" onclick="setSort('retreat')">
+                                <span class="inline-flex items-center gap-1" data-i18n="crm_retreat">Ретрит <span id="sort-retreat" class="text-xs opacity-50"></span></span>
+                            </th>
+                            <th class="cursor-pointer hover:bg-base-200" onclick="setSort('status')">
+                                <span class="inline-flex items-center gap-1" data-i18n="crm_prepayment_confirmation_status">Статус оплаты <span id="sort-status" class="text-xs opacity-50"></span></span>
+                            </th>
+                            <th class="cursor-pointer hover:bg-base-200" onclick="setSort('system')">
+                                <span class="inline-flex items-center gap-1" data-i18n="crm_payment_system">Платёжная система <span id="sort-system" class="text-xs opacity-50"></span></span>
+                            </th>
+                            <th class="cursor-pointer hover:bg-base-200 text-right" onclick="setSort('amount')">
+                                <span class="inline-flex items-center gap-1 justify-end" data-i18n="crm_amount">Сумма <span id="sort-amount" class="text-xs opacity-50"></span></span>
+                            </th>
+                            <th class="cursor-pointer hover:bg-base-200" onclick="setSort('received_at')">
+                                <span class="inline-flex items-center gap-1" data-i18n="crm_payment_date">Дата платежа <span id="sort-received_at" class="text-xs opacity-50"></span></span>
+                            </th>
+                            <th data-i18n="crm_manager">Менеджер</th>
+                            <th class="cursor-pointer hover:bg-base-200" onclick="setSort('created')">
+                                <span class="inline-flex items-center gap-1" data-i18n="crm_created">Создано <span id="sort-created" class="text-xs opacity-50"></span></span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody id="prepaymentsTable">
+                        <tr><td colspan="8" class="text-center py-8">
+                            <span class="loading loading-spinner loading-md"></span>
+                        </td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</main>
+
+<div id="footer-placeholder"></div>
+
+<script src="../js/config.js?v=4"></script>
+<script src="../js/auth-check.js?v=6"></script>
+<script src="../js/cache.js?v=1"></script>
+<script src="../js/utils.js?v=4"></script>
+<script src="../js/layout.js?v=12"></script>
+<script src="../js/date-utils.js?v=3"></script>
+<script src="../js/crm-utils.js?v=3"></script>
+
+<script>
+const t = key => Layout.t(key);
+const e = str => Layout.escapeHtml(str);
+
+// ==================== STATE ====================
+const DEAL_STATUSES_ALLOWED = ['invoiced', 'booked', 'checklist', 'ready', 'completed'];
+let prepayments = [];
+let filtered = [];
+let retreats = [];
+let paymentSystems = [];
+let currencies = [];
+let sortField = 'created';
+let sortDir = 'desc';
+let debounceTimer = null;
+
+const canConfirm = () => !!window.hasPermission?.('confirm_prepayment');
+
+// ==================== DATA ====================
+async function loadAll() {
+    const [retreatsRes, systemsRes, currenciesRes, paymentsRes] = await Promise.all([
+        Layout.db.from('retreats').select('id, name_ru, name_en, color, start_date').order('start_date', { ascending: false }),
+        Layout.db.from('crm_payment_systems').select('*').eq('is_archived', false).order('sort_order'),
+        Layout.db.from('crm_currencies').select('*').order('sort_order'),
+        Layout.db.from('crm_payments')
+            .select(`
+                *,
+                payment_system:payment_system_id(id, code, name_ru, name_en),
+                deal:deal_id(
+                    id, status, retreat_id,
+                    retreats:retreat_id(id, name_ru, name_en, color),
+                    vaishnavas:vaishnava_id(id, spiritual_name, first_name, last_name, phone, email),
+                    manager:manager_id(id, spiritual_name, first_name, last_name)
+                )
+            `)
+            .eq('payment_type', 'org_fee')
+            .order('created_at', { ascending: false })
+    ]);
+
+    retreats = retreatsRes.data || [];
+    paymentSystems = systemsRes.data || [];
+    currencies = currenciesRes.data || [];
+
+    // Клиентский фильтр по статусу сделки — embed-уровень фильтрации в Supabase слишком громоздкий
+    prepayments = (paymentsRes.data || []).filter(p => p.deal && DEAL_STATUSES_ALLOWED.includes(p.deal.status));
+
+    populateFilters();
+    applyFilters();
+}
+
+function populateFilters() {
+    const retreatSelect = document.getElementById('filterRetreat');
+    retreats.forEach(r => {
+        retreatSelect.insertAdjacentHTML('beforeend', `<option value="${r.id}">${e(Layout.getName(r))}</option>`);
+    });
+
+    const systemSelect = document.getElementById('filterSystem');
+    paymentSystems.forEach(s => {
+        systemSelect.insertAdjacentHTML('beforeend', `<option value="${s.id}">${e(Layout.getName(s))}</option>`);
+    });
+}
+
+// ==================== FILTERS ====================
+function applyFilters() {
+    const retreatId = document.getElementById('filterRetreat').value;
+    const status = document.getElementById('filterStatus').value;
+    const systemId = document.getElementById('filterSystem').value;
+    const search = document.getElementById('filterSearch').value.toLowerCase().trim();
+
+    filtered = prepayments.filter(p => {
+        if (retreatId && p.deal?.retreat_id !== retreatId) return false;
+        if (status === 'confirmed' && !p.is_confirmed) return false;
+        if (status === 'not_confirmed' && p.is_confirmed) return false;
+        if (systemId && p.payment_system_id !== systemId) return false;
+
+        if (search) {
+            const g = p.deal?.vaishnavas;
+            const str = [g?.spiritual_name, g?.first_name, g?.last_name, g?.phone, g?.email]
+                .filter(Boolean).join(' ').toLowerCase();
+            if (!str.includes(search)) return false;
+        }
+        return true;
+    });
+
+    sortData();
+    renderTable();
+    renderStats();
+}
+
+function applyFiltersDebounced() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(applyFilters, 300);
+}
+
+function resetFilters() {
+    document.getElementById('filterRetreat').value = '';
+    document.getElementById('filterStatus').value = '';
+    document.getElementById('filterSystem').value = '';
+    document.getElementById('filterSearch').value = '';
+    applyFilters();
+}
+
+// ==================== SORTING ====================
+function setSort(field) {
+    if (sortField === field) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    else { sortField = field; sortDir = 'asc'; }
+    updateSortIndicators();
+    sortData();
+    renderTable();
+}
+
+function updateSortIndicators() {
+    ['guest', 'retreat', 'status', 'system', 'amount', 'received_at', 'created'].forEach(f => {
+        const el = document.getElementById(`sort-${f}`);
+        if (el) el.textContent = sortField === f ? (sortDir === 'asc' ? '↑' : '↓') : '';
+    });
+}
+
+function sortData() {
+    filtered.sort((a, b) => {
+        let av, bv;
+        switch (sortField) {
+            case 'guest':
+                av = CrmUtils.getGuestName(a.deal?.vaishnavas).toLowerCase();
+                bv = CrmUtils.getGuestName(b.deal?.vaishnavas).toLowerCase();
+                break;
+            case 'retreat':
+                av = (Layout.getName(a.deal?.retreats) || '').toLowerCase();
+                bv = (Layout.getName(b.deal?.retreats) || '').toLowerCase();
+                break;
+            case 'status':
+                av = a.is_confirmed ? 1 : 0;
+                bv = b.is_confirmed ? 1 : 0;
+                break;
+            case 'system':
+                av = (Layout.getName(a.payment_system) || '').toLowerCase();
+                bv = (Layout.getName(b.payment_system) || '').toLowerCase();
+                break;
+            case 'amount':
+                av = Number(a.amount_inr || 0);
+                bv = Number(b.amount_inr || 0);
+                break;
+            case 'received_at':
+                av = a.received_at || '';
+                bv = b.received_at || '';
+                break;
+            case 'created':
+            default:
+                av = a.created_at || '';
+                bv = b.created_at || '';
+                break;
+        }
+        if (av < bv) return sortDir === 'asc' ? -1 : 1;
+        if (av > bv) return sortDir === 'asc' ? 1 : -1;
+        return 0;
+    });
+}
+
+// ==================== RENDER ====================
+function renderTable() {
+    const tbody = document.getElementById('prepaymentsTable');
+    if (filtered.length === 0) {
+        tbody.innerHTML = `<tr><td colspan="8" class="text-center py-8 text-base-content/50">${t('crm_no_prepayments')}</td></tr>`;
+        return;
+    }
+
+    tbody.innerHTML = filtered.map(p => {
+        const guest = p.deal?.vaishnavas;
+        const retreat = p.deal?.retreats;
+        const manager = p.deal?.manager;
+        return `
+            <tr class="prepayment-row" data-id="${p.id}">
+                <td>
+                    <a href="deal.html?id=${p.deal?.id}" class="hover:underline">
+                        <div class="font-medium">${e(CrmUtils.getGuestName(guest))}</div>
+                        <div class="text-xs text-base-content/50">${e(guest?.phone || guest?.email || '')}</div>
+                    </a>
+                </td>
+                <td>
+                    <span class="badge badge-sm whitespace-nowrap" style="background-color: ${retreat?.color || '#6b7280'}; color: white;">
+                        ${e(Layout.getName(retreat) || '—')}
+                    </span>
+                </td>
+                <td data-field="status">${renderStatusCell(p)}</td>
+                <td data-field="system">${renderSystemCell(p)}</td>
+                <td data-field="amount" class="text-right">${renderAmountCell(p)}</td>
+                <td data-field="received_at">${renderDateCell(p)}</td>
+                <td class="text-sm">${manager ? e(CrmUtils.getGuestShortName(manager)) : '<span class="text-base-content/30">—</span>'}</td>
+                <td class="text-sm text-base-content/50">${CrmUtils.formatDate(p.created_at)}</td>
+            </tr>
+        `;
+    }).join('');
+}
+
+function renderStatusCell(p) {
+    const confirmed = p.is_confirmed;
+    const clickable = canConfirm();
+    const cls = `status-chip ${confirmed ? 'confirmed' : 'not-confirmed'} ${clickable ? 'clickable' : ''}`;
+    const label = confirmed ? t('crm_prepayment_confirmed') : t('crm_prepayment_not_confirmed');
+    const onclick = clickable ? `onclick="toggleStatus('${p.id}')"` : '';
+    return `<span class="${cls}" ${onclick}>
+        <span class="status-dot ${confirmed ? 'confirmed' : 'not-confirmed'}"></span>
+        ${e(label)}
+    </span>`;
+}
+
+function renderSystemCell(p) {
+    const name = p.payment_system ? Layout.getName(p.payment_system) : '—';
+    return `<div class="inline-edit-cell" onclick="editSystem('${p.id}', this)">${e(name)}</div>`;
+}
+
+function renderAmountCell(p) {
+    const amount = CrmUtils.formatMoney(p.amount, p.currency);
+    const inr = p.currency !== 'INR'
+        ? `<div class="text-xs text-base-content/50">≈ ${CrmUtils.formatMoney(p.amount_inr)} (курс ${p.rate_to_inr})</div>`
+        : '';
+    return `<div class="inline-edit-cell text-right" onclick="editAmount('${p.id}', this)">
+        <div class="font-mono font-bold">${amount}</div>
+        ${inr}
+    </div>`;
+}
+
+function renderDateCell(p) {
+    const d = p.received_at ? DateUtils.parseDate(p.received_at.slice(0, 10)).toLocaleDateString('ru-RU') : '—';
+    return `<div class="inline-edit-cell" onclick="editDate('${p.id}', this)">${e(d)}</div>`;
+}
+
+function renderStats() {
+    const total = filtered.length;
+    document.getElementById('statsTotal').textContent = `${t('crm_found')}: ${total}`;
+
+    const unconfirmed = filtered.filter(p => !p.is_confirmed).length;
+    const unconfirmedEl = document.getElementById('statsUnconfirmed');
+    if (unconfirmed > 0) {
+        unconfirmedEl.textContent = `Не подтверждено: ${unconfirmed}`;
+        unconfirmedEl.classList.remove('hidden');
+    } else {
+        unconfirmedEl.classList.add('hidden');
+    }
+}
+
+// ==================== INLINE EDITORS ====================
+function findPayment(id) { return prepayments.find(x => x.id === id); }
+
+function flashRow(id) {
+    const row = document.querySelector(`tr[data-id="${id}"]`);
+    if (!row) return;
+    row.classList.add('flash-saved');
+    setTimeout(() => row.classList.remove('flash-saved'), 900);
+}
+
+async function savePatch(id, patch) {
+    const { data, error } = await Layout.db
+        .from('crm_payments')
+        .update(patch)
+        .eq('id', id)
+        .select(`
+            *,
+            payment_system:payment_system_id(id, code, name_ru, name_en)
+        `)
+        .single();
+    if (error) { Layout.handleError(error, 'Сохранение'); return null; }
+    // Обновляем локальный кэш (deal/retreat/vaishnavas в data отсутствуют — их не трогаем)
+    const p = findPayment(id);
+    if (p && data) {
+        Object.assign(p, data);
+    }
+    Layout.showNotification(t('crm_saved'), 'success');
+    flashRow(id);
+    return p;
+}
+
+async function toggleStatus(id) {
+    if (!canConfirm()) return;
+    const p = findPayment(id);
+    if (!p) return;
+    const patch = {
+        is_confirmed: !p.is_confirmed,
+        confirmed_at: !p.is_confirmed ? new Date().toISOString() : null,
+        confirmed_by: !p.is_confirmed ? (window.currentUser?.vaishnava_id || null) : null
+    };
+    await savePatch(id, patch);
+    applyFilters();
+    Layout.refreshPrepaymentsBadge?.();
+}
+
+function editSystem(id, cellEl) {
+    if (cellEl.querySelector('select')) return;
+    const p = findPayment(id);
+    const current = p?.payment_system_id || '';
+    const select = document.createElement('select');
+    select.className = 'select select-bordered select-sm w-full';
+    select.innerHTML = paymentSystems.map(s =>
+        `<option value="${s.id}" ${s.id === current ? 'selected' : ''}>${e(Layout.getName(s))}</option>`
+    ).join('');
+    cellEl.innerHTML = '';
+    cellEl.appendChild(select);
+    select.focus();
+
+    const commit = async () => {
+        const newId = select.value;
+        if (newId && newId !== current) {
+            await savePatch(id, { payment_system_id: newId });
+        }
+        applyFilters();
+    };
+    select.addEventListener('change', commit);
+    select.addEventListener('blur', commit);
+}
+
+function editAmount(id, cellEl) {
+    if (cellEl.querySelector('input')) return;
+    const p = findPayment(id);
+    if (!p) return;
+
+    const currentCurrency = p.currency || 'INR';
+    cellEl.innerHTML = `
+        <div class="flex items-center gap-1 justify-end">
+            <input type="number" class="input input-bordered input-sm w-24 text-right" data-role="amount" value="${p.amount}" step="0.01" min="0">
+            <select class="select select-bordered select-sm" data-role="currency">
+                ${currencies.map(c => `<option value="${c.code}" data-rate="${c.rate_to_inr}" ${c.code === currentCurrency ? 'selected' : ''}>${c.code}</option>`).join('')}
+            </select>
+            ${currentCurrency !== 'INR' ? `<input type="number" class="input input-bordered input-sm w-20 text-right" data-role="rate" value="${p.rate_to_inr}" step="0.0001" min="0" title="Курс к ₹">` : ''}
+            <button class="btn btn-xs btn-ghost" data-role="cancel" title="Отмена">✕</button>
+        </div>
+    `;
+    const amountInput = cellEl.querySelector('[data-role="amount"]');
+    const currencySelect = cellEl.querySelector('[data-role="currency"]');
+    const cancelBtn = cellEl.querySelector('[data-role="cancel"]');
+    amountInput.focus();
+    amountInput.select();
+
+    currencySelect.addEventListener('change', () => {
+        // Пересобрать ячейку, если пользователь сменил валюту (чтобы появилось/исчезло поле курса)
+        const newCurrency = currencySelect.value;
+        const newRate = parseFloat(currencySelect.selectedOptions[0]?.dataset.rate) || 1;
+        const newAmount = parseFloat(amountInput.value) || 0;
+        // Применяем временно в модели (без сохранения)
+        p.currency = newCurrency;
+        p.rate_to_inr = newRate;
+        p.amount = newAmount;
+        editAmount(id, cellEl); // перерисовать редактор с/без поля курса
+    });
+
+    const commit = async () => {
+        const amount = parseFloat(amountInput.value);
+        const currency = currencySelect.value;
+        const rateInput = cellEl.querySelector('[data-role="rate"]');
+        const rate = rateInput ? parseFloat(rateInput.value) : (parseFloat(currencySelect.selectedOptions[0]?.dataset.rate) || 1);
+        if (!amount || amount <= 0) { applyFilters(); return; }
+
+        const changed = amount !== Number(p.amount) || currency !== p.currency || rate !== Number(p.rate_to_inr);
+        if (changed) {
+            await savePatch(id, {
+                amount,
+                currency,
+                rate_to_inr: rate,
+                amount_inr: amount * rate
+            });
+        }
+        applyFilters();
+    };
+
+    cancelBtn.addEventListener('click', () => applyFilters());
+    amountInput.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter') { ev.preventDefault(); commit(); }
+        if (ev.key === 'Escape') { ev.preventDefault(); applyFilters(); }
+    });
+    amountInput.addEventListener('blur', (ev) => {
+        // Даём время клику по select/cancel
+        setTimeout(() => {
+            if (!cellEl.contains(document.activeElement)) commit();
+        }, 150);
+    });
+}
+
+function editDate(id, cellEl) {
+    if (cellEl.querySelector('input')) return;
+    const p = findPayment(id);
+    if (!p) return;
+    const currentIso = p.received_at ? p.received_at.slice(0, 10) : DateUtils.toISO(new Date());
+    const input = document.createElement('input');
+    input.type = 'date';
+    input.className = 'input input-bordered input-sm';
+    input.value = currentIso;
+    cellEl.innerHTML = '';
+    cellEl.appendChild(input);
+    input.focus();
+
+    const commit = async () => {
+        const newDate = input.value;
+        if (newDate && newDate !== currentIso) {
+            await savePatch(id, { received_at: newDate + 'T12:00:00' });
+        }
+        applyFilters();
+    };
+
+    input.addEventListener('change', commit);
+    input.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter') { ev.preventDefault(); commit(); }
+        if (ev.key === 'Escape') { ev.preventDefault(); applyFilters(); }
+    });
+    input.addEventListener('blur', commit);
+}
+
+// ==================== EXPORT ====================
+function exportXlsx() {
+    if (filtered.length === 0) { Layout.showNotification(t('crm_no_data_export'), 'error'); return; }
+    const BOM = '\uFEFF';
+    const headers = [
+        t('crm_guest'), t('crm_phone'), t('crm_retreat'),
+        t('crm_prepayment_confirmation_status'), t('crm_payment_system'),
+        `${t('crm_amount')} (orig)`, t('crm_currency'), `${t('crm_amount')} ₹`, 'Курс',
+        t('crm_payment_date'), t('crm_manager'), t('crm_created')
+    ];
+    const rows = filtered.map(p => {
+        const g = p.deal?.vaishnavas;
+        return [
+            CrmUtils.getGuestName(g),
+            g?.phone || '',
+            Layout.getName(p.deal?.retreats) || '',
+            p.is_confirmed ? t('crm_prepayment_confirmed') : t('crm_prepayment_not_confirmed'),
+            p.payment_system ? Layout.getName(p.payment_system) : '',
+            p.amount,
+            p.currency,
+            p.amount_inr,
+            p.rate_to_inr,
+            p.received_at ? p.received_at.slice(0, 10) : '',
+            p.deal?.manager ? CrmUtils.getGuestShortName(p.deal.manager) : '',
+            CrmUtils.formatDate(p.created_at)
+        ];
+    });
+    const csv = BOM + [headers, ...rows]
+        .map(r => r.map(c => `"${String(c ?? '').replace(/"/g, '""')}"`).join(','))
+        .join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `crm-prepayments-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+// ==================== INIT ====================
+async function init() {
+    await Layout.init({
+        module: 'crm',
+        menuId: 'crm_sales',
+        itemId: 'crm_prepayments'
+    });
+
+    await loadAll();
+}
+
+init();
+</script>
+
+</body>
+</html>

--- a/crm/services.html
+++ b/crm/services.html
@@ -144,7 +144,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/tags.html
+++ b/crm/tags.html
@@ -92,7 +92,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/task-templates.html
+++ b/crm/task-templates.html
@@ -119,7 +119,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/tasks.html
+++ b/crm/tasks.html
@@ -152,7 +152,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 <script src="../js/date-utils.js?v=3"></script>
 

--- a/crm/templates.html
+++ b/crm/templates.html
@@ -104,7 +104,7 @@
 <script src="../js/auth-check.js?v=6"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/crm-utils.js?v=3"></script>
 

--- a/crm/utm-links.html
+++ b/crm/utm-links.html
@@ -105,7 +105,7 @@
 <script src="../js/config.js?v=4"></script>
 <script src="../js/cache.js?v=1"></script>
 <script src="../js/utils.js?v=4"></script>
-<script src="../js/layout.js?v=11"></script>
+<script src="../js/layout.js?v=12"></script>
 <script src="../js/date-utils.js?v=3"></script>
 <script src="../js/auth-check.js?v=6"></script>
 

--- a/guest-portal/contacts.html
+++ b/guest-portal/contacts.html
@@ -190,7 +190,7 @@
     <!-- Scripts -->
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=11"></script>
+    <script src="js/portal-layout.js?v=12"></script>
 
     <script>
         async function init() {

--- a/guest-portal/index.html
+++ b/guest-portal/index.html
@@ -986,7 +986,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=11"></script>
+    <script src="js/portal-layout.js?v=12"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
     <script src="js/portal-index.js?v=10"></script>

--- a/guest-portal/materials-admin.html
+++ b/guest-portal/materials-admin.html
@@ -250,7 +250,7 @@
     <!-- Scripts -->
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=11"></script>
+    <script src="js/portal-layout.js?v=12"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
 

--- a/guest-portal/retreats.html
+++ b/guest-portal/retreats.html
@@ -101,7 +101,7 @@
     <!-- Scripts -->
     <script src="js/portal-config.js?v=3"></script>
     <script src="js/portal-auth.js"></script>
-    <script src="js/portal-layout.js?v=11"></script>
+    <script src="js/portal-layout.js?v=12"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="js/portal-data.js?v=3"></script>
 

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
     <script src="js/utils.js?v=4"></script>
     <script src="js/translit.js"></script>
     <script src="js/auto-translate.js"></script>
-    <script src="js/layout.js?v=11"></script>
+    <script src="js/layout.js?v=12"></script>
     <script>
         window.onLanguageChange = function(lang) {
             Layout.updateAllTranslations();

--- a/js/layout.js
+++ b/js/layout.js
@@ -89,7 +89,8 @@ const modules = {
             { id: 'crm_sales', items: [
                 { id: 'crm_kanban', href: 'crm/index.html' },
                 { id: 'crm_deals', href: 'crm/deals.html' },
-                { id: 'crm_tasks', href: 'crm/tasks.html' }
+                { id: 'crm_tasks', href: 'crm/tasks.html' },
+                { id: 'crm_prepayments', href: 'crm/prepayments.html', badgeKey: 'crm_unconfirmed_prepayments' }
             ]},
             { id: 'crm_analytics', items: [
                 { id: 'crm_dashboard', href: 'crm/dashboard.html' },
@@ -220,6 +221,7 @@ const pagePermissions = {
     'crm/deals.html': 'view_crm',
     'crm/deal.html': 'view_crm',
     'crm/tasks.html': 'view_crm',
+    'crm/prepayments.html': 'view_crm',
 
     // CRM - Аналитика
     'crm/dashboard.html': 'view_crm_dashboard',
@@ -658,7 +660,7 @@ function getFooterHTML() {
             ${footerLinks.length > 1 ? `
             <nav class="flex flex-wrap justify-center gap-4 sm:gap-6 mb-4" id="footerNav">
                 ${footerLinks.map(item => `
-                    <a href="${adjustHref(item.href)}" class="text-sm font-medium uppercase tracking-wide ${item.id === currentPage.itemId ? 'text-primary' : 'opacity-60 hover:opacity-100'}">${t('nav_' + item.id)}</a>
+                    <a href="${adjustHref(item.href)}" class="text-sm font-medium uppercase tracking-wide ${item.id === currentPage.itemId ? 'text-primary' : 'opacity-60 hover:opacity-100'}">${t('nav_' + item.id)}${item.badgeKey ? renderMenuItemBadge(item.id) : ''}</a>
                 `).join('')}
             </nav>
             ` : '<div id="footerNav"></div>'}
@@ -786,6 +788,32 @@ function buildLocationOptions() {
     });
 }
 
+// Бейдж у пункта меню (например, счётчик неподтверждённых предоплат)
+function renderMenuItemBadge(itemId) {
+    return `<span class="menu-item-badge menu-item-badge-${itemId} inline-flex items-center justify-center ml-1.5 px-1.5 h-4 min-w-[16px] rounded-full bg-red-500 text-white text-[10px] font-bold hidden align-middle"></span>`;
+}
+
+function setMenuBadge(itemId, count) {
+    const n = Number(count) || 0;
+    document.querySelectorAll(`.menu-item-badge-${itemId}`).forEach(el => {
+        el.textContent = n > 0 ? n : '';
+        el.classList.toggle('hidden', n <= 0);
+    });
+}
+
+async function refreshPrepaymentsBadge() {
+    if (!window.hasPermission?.('view_crm')) return;
+    const { data, error } = await supabase
+        .from('crm_payments')
+        .select('id, deal:deal_id(status)')
+        .eq('is_confirmed', false)
+        .eq('payment_type', 'org_fee');
+    if (error) return;
+    const allowed = ['invoiced', 'booked', 'checklist', 'ready', 'completed'];
+    const count = (data || []).filter(p => allowed.includes(p.deal?.status)).length;
+    setMenuBadge('crm_prepayments', count);
+}
+
 function buildMobileMenu() {
     const nav = $('#mobileNav');
     if (!nav) return;
@@ -810,7 +838,7 @@ function buildMobileMenu() {
                     </svg>
                 </button>
                 <div class="submenu pl-4">
-                    ${items.map(item => `<a href="${adjustHref(item.href)}" class="block px-4 py-3 text-base font-medium rounded-lg hover:bg-base-200 ${item.id === currentPage.itemId ? 'text-primary' : ''}">${t('nav_' + item.id)}</a>`).join('')}
+                    ${items.map(item => `<a href="${adjustHref(item.href)}" class="block px-4 py-3 text-base font-medium rounded-lg hover:bg-base-200 ${item.id === currentPage.itemId ? 'text-primary' : ''}">${t('nav_' + item.id)}${item.badgeKey ? renderMenuItemBadge(item.id) : ''}</a>`).join('')}
                 </div>
             </div>
         `;
@@ -837,7 +865,7 @@ function buildSubmenuBar() {
         if (items.length === 1) return '';
         return `
             <nav class="container mx-auto ${centered ? 'justify-center' : 'px-4'} flex items-center submenu-group ${id !== currentPage.menuId ? 'hidden' : ''}" data-group="${id}">
-                ${items.map(item => `<a href="${adjustHref(item.href)}" class="submenu-link px-5 py-2 text-base font-semibold tracking-wide uppercase ${item.id === currentPage.itemId ? 'active' : 'text-white/70 hover:text-white'}">${t('nav_' + item.id)}</a>`).join('')}
+                ${items.map(item => `<a href="${adjustHref(item.href)}" class="submenu-link px-5 py-2 text-base font-semibold tracking-wide uppercase ${item.id === currentPage.itemId ? 'active' : 'text-white/70 hover:text-white'}">${t('nav_' + item.id)}${item.badgeKey ? renderMenuItemBadge(item.id) : ''}</a>`).join('')}
             </nav>
         `;
     }).join('');
@@ -1260,6 +1288,9 @@ async function initLayout(page = { module: null, menuId: 'kitchen', itemId: null
     // Применяем переводы ко всем data-i18n элементам на странице
     updateAllTranslations();
 
+    // Обновляем бейдж неподтверждённых предоплат (в фоне, не блокирует рендер)
+    if (currentModule === 'crm') refreshPrepaymentsBadge();
+
     return { db, currentLang, currentLocation, currentModule, locations };
 }
 
@@ -1367,6 +1398,8 @@ window.Layout = {
     openPhotoModal,
     logout,
     updateUserInfo,
+    setMenuBadge,
+    refreshPrepaymentsBadge,
     get currentLang() { return currentLang; },
     get currentLocation() { return currentLocation; },
     get currentModule() { return currentModule; },

--- a/kitchen/dictionaries.html
+++ b/kitchen/dictionaries.html
@@ -95,7 +95,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let currentTab = 'recipe_categories';

--- a/kitchen/menu-board.html
+++ b/kitchen/menu-board.html
@@ -394,7 +394,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script src="../js/pages/kitchen-menu-board.js?v=3"></script>
 </body>

--- a/kitchen/menu-templates.html
+++ b/kitchen/menu-templates.html
@@ -292,7 +292,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let templates = [];

--- a/kitchen/menu.html
+++ b/kitchen/menu.html
@@ -479,7 +479,7 @@
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script src="../js/pages/kitchen-menu.js?v=20"></script>
 </body>

--- a/kitchen/products.html
+++ b/kitchen/products.html
@@ -226,7 +226,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let currentCategory = 'all';

--- a/kitchen/recipe-edit.html
+++ b/kitchen/recipe-edit.html
@@ -379,7 +379,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let recipeId = null;

--- a/kitchen/recipe.html
+++ b/kitchen/recipe.html
@@ -262,7 +262,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let recipe = null;

--- a/kitchen/recipes.html
+++ b/kitchen/recipes.html
@@ -105,7 +105,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         const PAGE_SIZE = 50;

--- a/photos/manage.html
+++ b/photos/manage.html
@@ -345,7 +345,7 @@
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
 
     <!-- Page Logic -->
     <script src="../photos/js/manage.js"></script>

--- a/photos/search.html
+++ b/photos/search.html
@@ -200,7 +200,7 @@
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
 
     <!-- Page Logic -->
     <script src="../photos/js/search.js"></script>

--- a/photos/upload.html
+++ b/photos/upload.html
@@ -313,7 +313,7 @@
     <script src="../js/permissions-ui.js?v=2"></script>
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
 
     <!-- Upload Logic -->
     <script src="../photos/js/upload.js"></script>

--- a/placement/arrivals.html
+++ b/placement/arrivals.html
@@ -188,7 +188,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         const t = key => Layout.t(key);
 

--- a/placement/bookings.html
+++ b/placement/bookings.html
@@ -378,7 +378,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/pages/bookings.js"></script>
 </body>
 </html>

--- a/placement/departures.html
+++ b/placement/departures.html
@@ -175,7 +175,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/pages/departures.js"></script>
 
 </body>

--- a/placement/timeline.html
+++ b/placement/timeline.html
@@ -969,7 +969,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
     function toggleFullscreen(btn) {
         const isFS = document.body.classList.toggle('board-fullscreen');

--- a/placement/transfers.html
+++ b/placement/transfers.html
@@ -187,7 +187,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         let transfers = [];
         let residentsMap = new Map();

--- a/reception/buildings.html
+++ b/reception/buildings.html
@@ -159,7 +159,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let buildings = [];

--- a/reception/cleaning.html
+++ b/reception/cleaning.html
@@ -476,7 +476,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let cleaningData = []; // { date, rooms: [...] } - upcoming

--- a/reception/dictionaries.html
+++ b/reception/dictionaries.html
@@ -83,7 +83,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let currentTab = 'building_types';

--- a/reception/floor-plan-editor.html
+++ b/reception/floor-plan-editor.html
@@ -220,7 +220,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let building = null;

--- a/reception/floor-plan.html
+++ b/reception/floor-plan.html
@@ -279,7 +279,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let buildings = [];

--- a/reception/prasad.html
+++ b/reception/prasad.html
@@ -199,7 +199,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script>
         // ==================== STATE ====================

--- a/reception/residents-list.html
+++ b/reception/residents-list.html
@@ -146,7 +146,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let residents = [];

--- a/reception/rooms.html
+++ b/reception/rooms.html
@@ -223,7 +223,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let rooms = [];

--- a/settings/translations.html
+++ b/settings/translations.html
@@ -191,7 +191,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         const PAGE_SIZE = 50;

--- a/settings/user-management.html
+++ b/settings/user-management.html
@@ -187,7 +187,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         const db = window.supabaseClient;
 

--- a/settings/users.html
+++ b/settings/users.html
@@ -71,7 +71,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let users = [];

--- a/stock/inventory.html
+++ b/stock/inventory.html
@@ -194,7 +194,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let inventories = [];

--- a/stock/issue.html
+++ b/stock/issue.html
@@ -415,7 +415,7 @@
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/eating-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let issuances = [];

--- a/stock/receive.html
+++ b/stock/receive.html
@@ -399,7 +399,7 @@
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/eating-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let receipts = [];

--- a/stock/requests.html
+++ b/stock/requests.html
@@ -379,7 +379,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/eating-utils.js?v=3"></script>
     <script src="../js/pages/stock-requests.js?v=8"></script>
 

--- a/stock/stock-settings.html
+++ b/stock/stock-settings.html
@@ -229,7 +229,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let buyers = [];

--- a/stock/stock.html
+++ b/stock/stock.html
@@ -84,7 +84,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
         // ==================== STATE ====================
         let currentCategory = 'all';

--- a/supabase/165_crm_prepayments_translations.sql
+++ b/supabase/165_crm_prepayments_translations.sql
@@ -1,0 +1,17 @@
+-- Переводы для вкладки «Предоплата»
+
+INSERT INTO translations (key, ru, en, hi, context) VALUES
+  ('nav_crm_prepayments', 'Предоплата', 'Prepayments', 'अग्रिम भुगतान', 'Навигация CRM'),
+  ('crm_prepayments_page_title', 'Предоплата — CRM — ШРСК', 'Prepayments — CRM — SRSK', 'अग्रिम भुगतान — CRM — SRSK', 'Заголовок страницы'),
+  ('crm_prepayment_confirmed', 'Подтверждена', 'Confirmed', 'पुष्टि की गई', 'CRM Предоплата'),
+  ('crm_prepayment_not_confirmed', 'Не подтверждена', 'Not confirmed', 'पुष्टि नहीं हुई', 'CRM Предоплата'),
+  ('crm_prepayment_confirmation_status', 'Статус подтверждения', 'Confirmation status', 'पुष्टि स्थिति', 'CRM Предоплата'),
+  ('crm_payment_system', 'Платёжная система', 'Payment system', 'भुगतान प्रणाली', 'CRM Предоплата'),
+  ('crm_all_systems', 'Все системы', 'All systems', 'सभी प्रणालियाँ', 'CRM Предоплата'),
+  ('crm_all_statuses', 'Все статусы', 'All statuses', 'सभी स्थितियाँ', 'CRM Предоплата'),
+  ('crm_payment_history', 'История изменений', 'Change history', 'परिवर्तन इतिहास', 'CRM Предоплата'),
+  ('crm_no_prepayments', 'Нет предоплат', 'No prepayments', 'कोई अग्रिम भुगतान नहीं', 'CRM Предоплата'),
+  ('crm_saved', 'Сохранено', 'Saved', 'सहेजा गया', 'Общее')
+ON CONFLICT (key) DO UPDATE SET
+  ru = EXCLUDED.ru, en = EXCLUDED.en, hi = EXCLUDED.hi,
+  context = EXCLUDED.context, updated_at = NOW();

--- a/vaishnavas/groups.html
+++ b/vaishnavas/groups.html
@@ -123,7 +123,7 @@
     <script src="../js/cache.js?v=1"></script>
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/pages/groups.js"></script>
 
 </body>

--- a/vaishnavas/guests.html
+++ b/vaishnavas/guests.html
@@ -203,7 +203,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/vaishnavas-utils.js?v=2"></script>
     <script>
         const V = VaishnavasUtils;

--- a/vaishnavas/index.html
+++ b/vaishnavas/index.html
@@ -232,7 +232,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/vaishnavas-utils.js?v=2"></script>
     <script>
         const V = VaishnavasUtils;

--- a/vaishnavas/person.html
+++ b/vaishnavas/person.html
@@ -1020,7 +1020,7 @@
     <script src="../js/auto-translate.js"></script>
     <script src="../js/modal-utils.js?v=3"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/pages/person.js?v=11"></script>
 </body>
 </html>

--- a/vaishnavas/preliminary.html
+++ b/vaishnavas/preliminary.html
@@ -967,7 +967,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script>
     function toggleFullscreen(btn) {
         const isFS = document.body.classList.toggle('board-fullscreen');

--- a/vaishnavas/retreat-guests.html
+++ b/vaishnavas/retreat-guests.html
@@ -434,7 +434,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/modal-utils.js?v=3"></script>
     <script src="../js/pages/retreat-guests.js?v=2"></script>
 </body>

--- a/vaishnavas/retreat-prasad.html
+++ b/vaishnavas/retreat-prasad.html
@@ -117,7 +117,7 @@
     <script src="../js/utils.js?v=4"></script>
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/date-utils.js?v=3"></script>
     <script src="../js/pages/retreat-prasad.js?v=2"></script>
 </body>

--- a/vaishnavas/team.html
+++ b/vaishnavas/team.html
@@ -211,7 +211,7 @@
     <script src="../js/translit.js"></script>
     <script src="../js/auto-translate.js"></script>
     <script src="../js/date-utils.js?v=3"></script>
-    <script src="../js/layout.js?v=11"></script>
+    <script src="../js/layout.js?v=12"></script>
     <script src="../js/vaishnavas-utils.js?v=2"></script>
     <script>
         const V = VaishnavasUtils;


### PR DESCRIPTION
Часть 2 из 2 для вкладки «Предоплата» (ТЗ ~/Downloads/ТЗ_CRM_Предоплата.md). PR 1 ([#27](https://github.com/krupchanskiy/srsk/pull/27)) подготовил бэкенд.

## Новая страница [/crm/prepayments.html](crm/prepayments.html)

### Фильтр данных
- `payment_type = 'org_fee'`
- `deal.status IN ('invoiced', 'booked', 'checklist', 'ready', 'completed')` — т.е. только предоплаты оргвзносов у сделок со стадии «Выставлен счёт» и выше.

### Фильтры в UI
- Ретрит (все / конкретный)
- Статус подтверждения (все / подтверждена / не подтверждена)
- Платёжная система (все / конкретная из справочника)
- Поиск по имени/телефону/email гостя
- Кнопка «Сбросить»

### Таблица
- Колонки: Гость (ссылка на сделку), Ретрит, Статус, Платёжная система, Сумма (+ ₹-эквивалент и курс для не-рупий), Дата платежа, Менеджер, Создано.
- Сортировка по любой колонке.
- Счётчик «Найдено: N» + красным «Не подтверждено: N».
- Кнопка «Скачать .xlsx» (CSV с BOM для Excel).

### Инлайн-редактирование
- **Статус**: клик — toggle `is_confirmed`. Доступен только при `hasPermission('confirm_prepayment')` (Нитья-виласини и админы). Менеджерам виден как read-only chip без курсора.
- **Платёжная система**: клик — `<select>` → autosave на change/blur.
- **Сумма**: клик — поля amount + currency + rate (поле курса появляется только для не-INR валют, значение берётся из `crm_currencies`, но редактируемо). Enter/blur — сохранение.
- **Дата платежа**: клик — `<input type=\"date\">` → autosave.
- После любого сохранения — flash-индикация зелёным на строке + тост «Сохранено».

## Бейдж на вкладке
- Красный счётчик неподтверждённых в пункте меню «Предоплата» (submenu + mobile + footer).
- Обновляется при открытии любой CRM-страницы (`Layout.refreshPrepaymentsBadge()` вызывается в `initLayout`, если module === crm).
- После toggle статуса на странице предоплат бейдж пересчитывается.

## layout.js
- Пункт `crm_prepayments` в секции `crm_sales` с `badgeKey: 'crm_unconfirmed_prepayments'`.
- `pagePermissions['crm/prepayments.html'] = 'view_crm'`.
- Утилиты: `renderMenuItemBadge(itemId)`, `setMenuBadge(itemId, count)`, `refreshPrepaymentsBadge()`.
- Бамп версии `layout.js?v=11 → v=12` во всех HTML (sed).

## [crm/deal.html](crm/deal.html)
- В модалке деталей платежа добавлена кнопка «История изменений» — открывает новую модалку `paymentHistoryModal` с событиями из `crm_payment_history` (создание, подтверждение, отмена подтверждения, изменение суммы/системы/даты; показывается кто и когда).

## Миграция [165](supabase/165_crm_prepayments_translations.sql)
Переводы ru/en/hi для всех новых UI-ключей: `nav_crm_prepayments`, `crm_prepayment_confirmed/not_confirmed/confirmation_status`, `crm_payment_system`, `crm_all_systems/statuses`, `crm_payment_history`, `crm_no_prepayments`, `crm_saved`. **Уже применена** через MCP в production.

## Test plan
- [ ] Переход «Продажи → Предоплата» работает, страница загружается
- [ ] В пункте меню «Предоплата» виден красный бейдж с количеством неподтверждённых (сейчас 0, т.к. все существующие платежи были автоподтверждены в PR 1)
- [ ] Фильтры — ретрит, статус, платёжная система, поиск — фильтруют таблицу
- [ ] Сортировка по колонкам
- [ ] Нитья-виласини: клик на статус → toggle (статус меняется, бейдж обновляется)
- [ ] Менеджер (Юля Б./Наталья Е.): статус read-only, курсор не pointer
- [ ] Клик на платёжную систему → select, autosave
- [ ] Клик на сумму: появляются поля, можно сменить валюту (поле курса появляется/исчезает), Enter сохраняет
- [ ] Клик на дату → date picker, autosave
- [ ] Flash-индикация зелёным после сохранения
- [ ] Экспорт .xlsx выгружает текущий фильтр
- [ ] В карточке сделки → клик на платёж → «История изменений» → модалка с событиями

🤖 Generated with [Claude Code](https://claude.com/claude-code)