### PR TITLE
fix(crm): показывать неподтверждённые платежи в карточке и таблице

### DIFF
--- a/crm/deal.html
+++ b/crm/deal.html
@@ -228,6 +228,10 @@
                             <span class="text-base-content/60" data-i18n="crm_paid">Оплачено (₹)</span>
                             <span class="font-mono font-bold text-emerald-600" id="financePaid">—</span>
                         </div>
+                        <div class="flex justify-between text-sm hidden" id="financePendingRow">
+                            <span class="text-base-content/60">Ждёт подтверждения</span>
+                            <span class="font-mono font-bold text-amber-600" id="financePending">—</span>
+                        </div>
                         <div class="flex justify-between text-sm font-bold pt-1 border-t border-base-200">
                             <span class="text-base-content/60" data-i18n="crm_balance">Баланс</span>
                             <span class="font-mono" id="financeBalance">—</span>
@@ -1232,7 +1236,16 @@ function renderFinanceBlock() {
 
     // Итого оплачено (в рупиях) — только подтверждённые для консистентности с total_paid
     const confirmedInr = payments.filter(p => p.is_confirmed).reduce((sum, p) => sum + Number(p.amount_inr || 0), 0);
+    const unconfirmedInr = payments.filter(p => !p.is_confirmed).reduce((sum, p) => sum + Number(p.amount_inr || 0), 0);
     document.getElementById('financePaid').textContent = CrmUtils.formatMoney(confirmedInr);
+
+    const pendingRow = document.getElementById('financePendingRow');
+    if (unconfirmedInr > 0) {
+        document.getElementById('financePending').textContent = CrmUtils.formatMoney(unconfirmedInr);
+        pendingRow.classList.remove('hidden');
+    } else {
+        pendingRow.classList.add('hidden');
+    }
 
     // Начислено и баланс
     const charged = deal ? (deal.total_charged || 0) : 0;

--- a/crm/deals.html
+++ b/crm/deals.html
@@ -355,7 +355,7 @@ async function loadDeals() {
             vaishnavas:vaishnava_id(id, spiritual_name, first_name, last_name, phone, email),
             retreats:retreat_id(id, name_ru, name_en, color),
             manager:manager_id(id, spiritual_name, first_name, last_name),
-            crm_payments(is_confirmed)
+            crm_payments(is_confirmed, amount_inr)
         `)
         .order('created_at', { ascending: false });
 
@@ -578,19 +578,22 @@ function renderTable() {
 
 function renderPaidCell(d) {
     const payments = d.crm_payments || [];
-    const amountStr = d.total_paid > 0
-        ? CrmUtils.formatMoney(d.total_paid)
-        : '<span class="text-base-content/30">—</span>';
+    if (payments.length === 0) {
+        return '<span class="text-base-content/30">—</span>';
+    }
 
-    if (payments.length === 0) return amountStr;
+    const confirmed = payments.filter(p => p.is_confirmed).reduce((s, p) => s + Number(p.amount_inr || 0), 0);
+    const unconfirmed = payments.filter(p => !p.is_confirmed).reduce((s, p) => s + Number(p.amount_inr || 0), 0);
+    const total = confirmed + unconfirmed;
 
-    const hasUnconfirmed = payments.some(p => !p.is_confirmed);
-    const color = hasUnconfirmed ? '#f59e0b' : '#22c55e';
-    const title = hasUnconfirmed
-        ? 'Есть неподтверждённый платёж'
-        : 'Все платежи подтверждены';
+    const allConfirmed = unconfirmed === 0;
+    const dotColor = allConfirmed ? '#22c55e' : '#f59e0b';
+    const textClass = allConfirmed ? '' : 'text-amber-700';
+    const title = allConfirmed
+        ? 'Все платежи подтверждены'
+        : `Подтверждено: ${CrmUtils.formatMoney(confirmed)}. Ждёт подтверждения: ${CrmUtils.formatMoney(unconfirmed)}`;
 
-    return `${amountStr}<span class="inline-block w-2.5 h-2.5 rounded-full ml-2 align-middle" style="background:${color}" title="${title}"></span>`;
+    return `<span class="${textClass}">${CrmUtils.formatMoney(total)}</span><span class="inline-block w-2.5 h-2.5 rounded-full ml-2 align-middle" style="background:${dotColor}" title="${title}"></span>`;
 }
 
 function renderChecklistDots(d) {


### PR DESCRIPTION
Фикс по жалобе после выката PR [#29](https://github.com/krupchanskiy/srsk/pull/29) (откат автоподтверждения):

> «Пропали совсем данные о том, что менеджеры ОП приняли оплату. Да, она ещё не подтверждена, но при этом не должно быть такого, что её нигде не видно в карточке!»

## Что было
- В колонке «Оплачено» таблицы `/crm/deals.html` при всех неподтверждённых платежах показывался прочерк (`d.total_paid=0`).
- В блоке «Финансы» сайдбара карточки сделки строка «Оплачено (₹)» показывала ₹0.
- Факт внесения платежа был виден только по счётчику на вкладке «Оплаты N» — неочевидно.

## Что стало

### [crm/deals.html](crm/deals.html)
`renderPaidCell` теперь показывает **сумму всех платежей** (confirmed + unconfirmed) в колонке «Оплачено».
- 🟢 зелёная точка — все платежи подтверждены, обычный цвет текста.
- 🟡 оранжевая точка + оранжевый текст — есть хотя бы один неподтверждённый.
- Tooltip: «Подтверждено: ₹X. Ждёт подтверждения: ₹Y».
- Запрос расширен `crm_payments(is_confirmed, amount_inr)`.

### [crm/deal.html](crm/deal.html) — блок «Финансы» в сайдбаре
Между «Оплачено» и «Баланс» появляется строка «Ждёт подтверждения» (оранжевая) — **только когда есть неподтверждённые** (`unconfirmedInr > 0`), иначе скрыта.
- «Оплачено» остаётся суммой подтверждённых (консистентно с `total_paid` в БД и дашбордом).
- «Баланс» считается по подтверждённым (если платёж «ждёт подтверждения», долг формально не закрыт).

## Test plan
- [ ] Открыть сделку с неподтверждённым платежом — в сайдбаре «Финансы»:
  - «Оплачено ₹0» (emerald)
  - «Ждёт подтверждения ₹X» (amber)
  - «Баланс −₹charged» (rose)
- [ ] Подтвердить платёж на `/crm/prepayments.html` — строка «Ждёт подтверждения» пропадает, «Оплачено» подхватывает сумму.
- [ ] В `/crm/deals.html` в колонке «Оплачено»: у сделок с неподтв. — оранжевая сумма + 🟡; у сделок только с подтв. — обычная + 🟢.

🤖 Generated with [Claude Code](https://claude.com/claude-code)