### PR TITLE
feat(crm): неподтверждённый платёж в сайдбаре сделки выделяется целиком

### DIFF
--- a/crm/deal.html
+++ b/crm/deal.html
@@ -1214,19 +1214,21 @@ function renderFinanceBlock() {
                 : '—';
             const typeLabel = t('crm_payment_type_' + p.payment_type) || p.payment_type || '';
             const dotColor = p.is_confirmed ? '#22c55e' : '#f59e0b';
-            const dotTitle = p.is_confirmed ? 'Платёж подтверждён' : 'Платёж не подтверждён';
+            const dotTitle = p.is_confirmed ? 'Платёж подтверждён' : 'Платёж не подтверждён (ждёт подтверждения)';
+            const rowCls = p.is_confirmed ? '' : 'bg-amber-50 ring-1 ring-amber-200';
+            const textCls = p.is_confirmed ? '' : 'text-amber-700';
             return `
-                <div class="group py-0.5 cursor-pointer hover:bg-base-200 rounded px-1 -mx-1" onclick="showPaymentDetails('${p.id}')">
-                    <div class="flex items-center gap-1.5 text-xs">
-                        <span class="inline-block w-2 h-2 rounded-full shrink-0" style="background:${dotColor}" title="${dotTitle}"></span>
-                        <span class="text-base-content/50 w-12 shrink-0">${e(dateStr)}</span>
-                        <span class="text-base-content/60 flex-1 truncate">${e(typeLabel)}</span>
+                <div class="group py-1 cursor-pointer hover:brightness-95 rounded px-1.5 -mx-1 ${rowCls}" onclick="showPaymentDetails('${p.id}')" title="${dotTitle}">
+                    <div class="flex items-center gap-1.5 text-xs ${textCls}">
+                        <span class="inline-block w-2.5 h-2.5 rounded-full shrink-0" style="background:${dotColor}"></span>
+                        <span class="opacity-70 w-12 shrink-0">${e(dateStr)}</span>
+                        <span class="opacity-80 flex-1 truncate">${e(typeLabel)}</span>
                         <span class="font-mono">${CrmUtils.formatMoney(p.amount, p.currency)}</span>
-                        <span class="text-base-content/30">→</span>
+                        <span class="opacity-40">→</span>
                         <span class="font-mono font-semibold">${CrmUtils.formatMoney(p.amount_inr)}</span>
                         <button class="btn btn-ghost btn-xs text-error h-5 min-h-5 px-1 opacity-0 group-hover:opacity-100" onclick="event.stopPropagation(); deletePayment('${p.id}')">×</button>
                     </div>
-                    ${p.notes ? `<div class="text-xs text-base-content/40 pl-12 truncate">${e(p.notes)}</div>` : ''}
+                    ${p.notes ? `<div class="text-xs opacity-60 pl-[22px] truncate ${textCls}">${e(p.notes)}</div>` : ''}
                 </div>
             `;
         }).join('');


### PR DESCRIPTION
По вопросу «где в карточке сделки увидеть неподтверждённый платёж?»:

До фикса в блоке «Финансы» (сайдбар) неподтверждённый платёж отличался от подтверждённого только мелкой оранжевой точкой 8×8 px. Легко пропустить.

## Что стало
Строка платежа в [crm/deal.html](crm/deal.html) (`financePaymentsList`) — целиком оранжевая, когда платёж не подтверждён:
- фон `bg-amber-50`
- кольцо `ring-1 ring-amber-200`
- весь текст `text-amber-700`
- точка увеличена с 8×8 до 10×10 px
- тултип на всей строке: «Платёж не подтверждён (ждёт подтверждения)»

Подтверждённые платежи остаются в обычном виде с зелёной точкой.

Где ещё в карточке виден неподтверждённый платёж (суммарно):
1. **Сайдбар «Финансы»** — теперь вся строка оранжевая + агрегатная строка «Ждёт подтверждения» (amber) под «Оплачено».
2. **Вкладка «Оплаты N»** — таблица с колонкой статуса + оранжевая точка + «Платёжная система».
3. **Модалка деталей платежа** при клике по платежу — строка «Статус: ○ Не подтверждён» (amber).
4. **Канбан** ([crm/index.html](crm/index.html)) — оранжевая сумма на карточке сделки.
5. **Таблица сделок** ([crm/deals.html](crm/deals.html)) — оранжевая сумма в колонке «Оплачено» + точка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)