### PR TITLE
fix(crm): embed received_by с явным FK-хинтом — платежи снова видны в карточке

### DIFF
--- a/crm/deal.html
+++ b/crm/deal.html
@@ -720,7 +720,7 @@ async function loadDealServices() {
 async function loadPayments() {
     const { data } = await Layout.db
         .from('crm_payments')
-        .select('*, received_by:vaishnavas(spiritual_name, first_name), payment_system:payment_system_id(id, code, name_ru, name_en)')
+        .select('*, received_by:vaishnavas!crm_payments_received_by_fkey(spiritual_name, first_name), payment_system:payment_system_id(id, code, name_ru, name_en)')
         .eq('deal_id', dealId)
         .order('received_at', { ascending: false });
     payments = data || [];


### PR DESCRIPTION
## Симптом
В карточке сделки, сайдбар «Финансы» → «Нет платежей», хотя в БД у сделки есть запись в `crm_payments` (обнаружено на сделке Айланы Умирбековой — 100 EUR на PayPal, не подтверждён).

## Диагностика
Запрос `loadPayments` возвращал **HTTP 300 Multiple Choices** (видно в логах PostgREST):
```
GET /rest/v1/crm_payments?select=*,received_by:vaishnavas(...),payment_system:...
```

Причина: миграция 163 (PR [#27](https://github.com/krupchanskiy/srsk/pull/27)) добавила `crm_payments.confirmed_by REFERENCES vaishnavas(id)`. Теперь **два FK** от `crm_payments` к `vaishnavas`:
- `crm_payments_received_by_fkey`
- `crm_payments_confirmed_by_fkey`

PostgREST не знает какой использовать для embed `received_by:vaishnavas(...)` и отдаёт 300. Supabase-JS парсит это как ошибку, `data=null`, `payments=[]`, UI → «Нет платежей».

## Фикс
В [crm/deal.html](crm/deal.html) `loadPayments` — явный FK-хинт:
```diff
- received_by:vaishnavas(spiritual_name, first_name)
+ received_by:vaishnavas!crm_payments_received_by_fkey(spiritual_name, first_name)
```

Проверено: других embed-ов `vaishnavas` с `crm_payments` в коде нет. В `crm_payment_history` тоже только один FK `changed_by_fkey`, так что там embed `changed_by:changed_by(...)` работает.

## Test plan
- [ ] Открыть сделку Айланы Умирбековой (или любую с платежом) — в блоке «Финансы» видна оранжевая строка с платежом.
- [ ] В логах PostgREST запрос на `crm_payments` отвечает 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)