### PR TITLE
fix(crm): embed received_by с явным FK-хинтом — платежи снова видны в карточке

### DIFF
--- a/crm/deal.html
+++ b/crm/deal.html
@@ -720,7 +720,7 @@ async function loadDealServices() {
 async function loadPayments() {
     const { data } = await Layout.db
         .from('crm_payments')
-        .select('*, received_by:vaishnavas(spiritual_name, first_name), payment_system:payment_system_id(id, code, name_ru, name_en)')
+        .select('*, received_by:vaishnavas!crm_payments_received_by_fkey(spiritual_name, first_name), payment_system:payment_system_id(id, code, name_ru, name_en)')
         .eq('deal_id', dealId)
         .order('received_at', { ascending: false });
     payments = data || [];


### PR DESCRIPTION
Повторная попытка после [PR #34](https://github.com/krupchanskiy/srsk/pull/34), который закрылся из-за сетевой ошибки.

## Симптом
В карточке сделки, сайдбар «Финансы» → «Нет платежей», хотя в БД у сделки есть запись в `crm_payments` (обнаружено на сделке Айланы Умирбековой — 100 EUR на PayPal, не подтверждён).

## Диагностика
Запрос `loadPayments` возвращал **HTTP 300 Multiple Choices** (видно в логах PostgREST): миграция 163 ([PR #27](https://github.com/krupchanskiy/srsk/pull/27)) добавила `crm_payments.confirmed_by REFERENCES vaishnavas(id)`. Теперь **два FK** от `crm_payments` к `vaishnavas`: `received_by_fkey` и `confirmed_by_fkey`. PostgREST не знает какой использовать для embed `received_by:vaishnavas(...)` → 300 → supabase-js возвращает `data=null` → `payments=[]` → UI «Нет платежей».

## Фикс
[crm/deal.html](crm/deal.html) `loadPayments`:
```diff
- received_by:vaishnavas(spiritual_name, first_name)
+ received_by:vaishnavas!crm_payments_received_by_fkey(spiritual_name, first_name)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)