### PR TITLE
chore(db): синхронизация superusers ↔ vaishnavas.is_superuser

### DIFF
--- a/supabase/167_sync_superusers.sql
+++ b/supabase/167_sync_superusers.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- Миграция 167: Синхронизация superusers ↔ vaishnavas.is_superuser
+-- =============================================================================
+-- Контекст: в системе две таблицы суперюзеров.
+--   • superusers — используется RLS-функциями (is_staff, политиками БД).
+--   • vaishnavas.is_superuser — читается фронтом (auth-check.js → window.currentUser.is_superuser).
+-- Они расходились: 13 пользователей в superusers, но НЕ в vaishnavas.is_superuser
+-- (Нитья-виласини, Премамрита, Ранганатх и др.) — RLS их пускал, UI прятал кнопки/модули.
+-- Плюс 1 наоборот (Нарада дас) — UI считал суперюзером, RLS — нет.
+--
+-- Решение по согласованию: привести vaishnavas.is_superuser в соответствие
+-- с superusers (источник истины), и зеркально добавить всех vaishnavas.is_superuser=true
+-- в superusers, чтобы две таблицы перестали расходиться.
+-- =============================================================================
+
+-- 1. Все из superusers → vaishnavas.is_superuser=TRUE
+UPDATE vaishnavas v
+   SET is_superuser = TRUE
+ WHERE v.user_id IS NOT NULL
+   AND v.is_superuser = FALSE
+   AND EXISTS (SELECT 1 FROM superusers s WHERE s.user_id = v.user_id);
+
+-- 2. Зеркально: все vaishnavas.is_superuser=TRUE без записи в superusers → добавить
+INSERT INTO superusers (user_id)
+SELECT v.user_id
+  FROM vaishnavas v
+ WHERE v.user_id IS NOT NULL
+   AND v.is_superuser = TRUE
+   AND NOT EXISTS (SELECT 1 FROM superusers s WHERE s.user_id = v.user_id)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Контекст
В системе две таблицы суперюзеров жили параллельно:
- `superusers (user_id)` — используется RLS-функциями БД (`is_staff()`, политики).
- `vaishnavas.is_superuser` — читается фронтом ([js/auth-check.js:39](js/auth-check.js:39)).

13 человек были в `superusers`, но НЕ в `vaishnavas.is_superuser` (Нитья-виласини, Премамрита, Ранганатх, Васудева Датта, Кунджавасини, Аударья-вилас, и др.). RLS пускал их к данным, UI прятал кнопки/модули и редиректил с защищённых страниц.

## Симптом
Нитья-виласини не могла открыть CRM-модуль:
- Карточка CRM на главной ведёт на `crm/dashboard.html` → требует `view_crm_dashboard`.
- Через роли (team_member + receptionist) у неё этого права нет.
- Auth-check видел `vaishnavas.is_superuser=false` → не пускал.
- Подтверждать предоплаты не могла, хотя по ТЗ должна была.

## Миграция [167](supabase/167_sync_superusers.sql)
```sql
-- 1. Все из superusers → vaishnavas.is_superuser=TRUE (13 строк)
UPDATE vaishnavas SET is_superuser=TRUE WHERE user_id IN (SELECT user_id FROM superusers) AND is_superuser=FALSE;

-- 2. Зеркально: 1 случай (Нарада дас) — vaishnavas.is_superuser=TRUE без superusers
INSERT INTO superusers (user_id) SELECT user_id FROM vaishnavas WHERE is_superuser=TRUE AND user_id NOT IN (SELECT user_id FROM superusers);
```

**Уже применена** через MCP. После: `desync_count=0`.

## Эффект
14 человек теперь действительно полноценные суперюзеры — и в БД, и в UI. Никто не теряет доступа: они уже имели его через RLS, теперь UI согласован.

## Test plan
- [ ] Нитья-виласини логинится → видит карточку CRM на главной → открывает → попадает в дашборд → видит вкладку «Предоплата» → может тоггать статус.
- [ ] На главной у неё появляются модули «Управление» (раз is_superuser=true) и «Фото» (raз есть upload_photos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)