### PR TITLE
fix(crm): убрать дубль текста на кнопке «Отправить заявку»

### DIFF
--- a/crm/form.html
+++ b/crm/form.html
@@ -83,7 +83,6 @@
             <div class="flex justify-end mt-6">
                 <button type="submit" class="btn btn-success gap-2" id="submitBtn">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-                    Отправить заявку
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- На странице `/crm/form.html` текст «Отправить заявку» дублировался: был статически в HTML и дополнительно вставлялся через i18n (`insertAdjacentHTML('afterend', ...)`).
- Удалил статический текст из HTML — теперь он приходит только из i18n, мультиязычность (RU/EN) сохранена.

## Test plan
- [ ] Открыть https://in.rupaseva.com/crm/form.html?retreat=8837f0e0-a428-4ae2-bb12-a870b3a5a6d7
- [ ] Убедиться, что на кнопке отправки текст «Отправить заявку» написан один раз
- [ ] Переключиться на `?lang=en` и проверить «Submit Application»
- [ ] Отправить заявку — кнопка показывает «Отправка…» во время сабмита и «Отправить заявку» после ошибки

🤖 Generated with [Claude Code](https://claude.com/claude-code)